### PR TITLE
Add new volume kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ See: `python/tests/test_cpp_kernels.py` for examples on how to interface with th
 See: `cpp/demo/main.cpp` for how to interface with the C++ layer.
 
 Currently implemented kernels for Lagrange elements (affine meshes):
-- `ufl.inner(u, v) * ufl.dx`
-- `ufl.inner(u, v) * ufl.ds`
-- `ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx`
-- `ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.ds`
-- `ufl.inner(ufl.sym(ufl.grad(u)), ufl.sym(ufl.grad(v))) * ufl.ds`
+- `ufl.inner(u, v) * ufl.dx` (3D)
+- `ufl.inner(u, v) * ufl.ds` (2D and 3D)
+- `ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx` (3D)
+- `ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.ds` (2D and 3D)
+- `ufl.inner(ufl.tr(ufl.sym(ufl.grad(u))), ufl.sym(ufl.grad(v))) * ufl.dx` (3D)
+- `2 * ufl.inner(ufl.sym(ufl.grad(u)), ufl.sym(ufl.grad(v))) * ufl.dx` (3D)
+- `ufl.inner(ufl.sym(ufl.grad(u)), ufl.sym(ufl.grad(v))) * ufl.ds` (2D and 3D)
 
 ## Dependencies
 DOLFINX_CUAS depends on DOLFINx and in turn its dependencies.

--- a/cpp/demo/surface/CMakeLists.txt
+++ b/cpp/demo/surface/CMakeLists.txt
@@ -14,7 +14,14 @@ find_package(Basix REQUIRED)
 find_package(xtensor REQUIRED)
 find_package(xtensor-blas REQUIRED)
 
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/problem.c
+  COMMAND ffcx ${CMAKE_CURRENT_SOURCE_DIR}/problem.ufl -o ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDS problem.ufl
+)
+
 add_executable(${PROJECT_NAME} main.cpp ${CMAKE_CURRENT_SOURCE_DIR}/problem.c)
+
 
 
 target_link_directories(${PROJECT_NAME} PRIVATE dolfinx_cuas)

--- a/cpp/demo/surface/create_contact_meshes.py
+++ b/cpp/demo/surface/create_contact_meshes.py
@@ -68,11 +68,11 @@ def create_circle_plane_mesh(filename: str):
     # Synchronize and create physical tags
     gmsh.model.occ.synchronize()
     gmsh.model.addPhysicalGroup(2, [surface])
-    bndry = gmsh.model.getBoundary((2, surface))
+    bndry = gmsh.model.getBoundary([(2, surface)])
     [gmsh.model.addPhysicalGroup(b[0], [b[1]]) for b in bndry]
 
     gmsh.model.addPhysicalGroup(2, [surface2], 2)
-    bndry2 = gmsh.model.getBoundary((2, surface2))
+    bndry2 = gmsh.model.getBoundary([(2, surface2)])
     [gmsh.model.addPhysicalGroup(b[0], [b[1]]) for b in bndry2]
 
     gmsh.model.mesh.field.add("Distance", 1)

--- a/cpp/demo/volume/main.cpp
+++ b/cpp/demo/volume/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char* argv[])
   MatZeroEntries(B.mat());
 
   // Generate Kernel
-  auto kernel = dolfinx_cuas::generate_kernel(dolfinx_cuas::Kernel::MassTensor, 1, 3);
+  auto kernel = dolfinx_cuas::generate_kernel(dolfinx_cuas::Kernel::MassTensor, 1, 1);
 
   // Define active cells
   const std::int32_t tdim = mesh->topology().dim();

--- a/cpp/demo/volume/main.cpp
+++ b/cpp/demo/volume/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char* argv[])
   MatZeroEntries(B.mat());
 
   // Generate Kernel
-  auto kernel = dolfinx_cuas::generate_kernel(dolfinx_cuas::Kernel::MassTensor, 1);
+  auto kernel = dolfinx_cuas::generate_kernel(dolfinx_cuas::Kernel::MassTensor, 1, 3);
 
   // Define active cells
   const std::int32_t tdim = mesh->topology().dim();

--- a/cpp/kernels.hpp
+++ b/cpp/kernels.hpp
@@ -44,11 +44,14 @@ kernel_fn generate_tet_kernel(dolfinx_cuas::Kernel type)
   constexpr std::int32_t d = 4;
   constexpr std::int32_t ndofs_cell = (P + 1) * (P + 2) * (P + 3) / 6;
 
+  // NOTE: These assumptions are only fine for simplices
   int quad_degree = 0;
   if (type == dolfinx_cuas::Kernel::Stiffness)
     quad_degree = (P - 1) + (P - 1);
   else if (type == dolfinx_cuas::Kernel::Mass or type == dolfinx_cuas::Kernel::MassTensor)
     quad_degree = 2 * P;
+  else if (type == dolfinx_cuas::Kernel::TrEps)
+    quad_degree = (P - 1) + (P - 1);
 
   auto [points, weight]
       = basix::quadrature::make_quadrature("default", basix::cell::str_to_type(cell), quad_degree);

--- a/cpp/surface_kernels.hpp
+++ b/cpp/surface_kernels.hpp
@@ -252,8 +252,8 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
           // Compute sum_t dphi^j/dx_t dphi^i/dx_t
           // Component is invarient of block size
           double block_invariant_cont = 0;
-          for (int t = 0; t < gdim; t++)
-            block_invariant_cont += dphi_phys(t, i) * dphi_phys(t, j);
+          for (int s = 0; s < gdim; s++)
+            block_invariant_cont += dphi_phys(s, i) * dphi_phys(s, j);
           block_invariant_cont *= 0.5 * w0;
 
           for (int k = 0; k < bs; ++k)

--- a/python/dolfinx_cuas/wrappers.cpp
+++ b/python/dolfinx_cuas/wrappers.cpp
@@ -58,8 +58,8 @@ PYBIND11_MODULE(cpp, m)
           return cuas_wrappers::KernelWrapper(
               dolfinx_cuas::generate_surface_kernel(V, type, quadrature_degree));
         });
-  m.def("generate_kernel", [](dolfinx_cuas::Kernel type, int p)
-        { return cuas_wrappers::KernelWrapper(dolfinx_cuas::generate_kernel(type, p)); });
+  m.def("generate_kernel", [](dolfinx_cuas::Kernel type, int p, int bs)
+        { return cuas_wrappers::KernelWrapper(dolfinx_cuas::generate_kernel(type, p, bs)); });
   m.def("assemble_exterior_facets",
         [](Mat A, std::shared_ptr<const dolfinx::fem::Form<PetscScalar>> a,
            const py::array_t<std::int32_t, py::array::c_style>& active_facets,
@@ -83,5 +83,6 @@ PYBIND11_MODULE(cpp, m)
   py::enum_<dolfinx_cuas::Kernel>(m, "Kernel")
       .value("Mass", dolfinx_cuas::Kernel::Mass)
       .value("Stiffness", dolfinx_cuas::Kernel::Stiffness)
-      .value("SymGrad", dolfinx_cuas::Kernel::SymGrad);
+      .value("SymGrad", dolfinx_cuas::Kernel::SymGrad)
+      .value("TrEps", dolfinx_cuas::Kernel::TrEps);
 }

--- a/python/tests/test_cpp_kernels.py
+++ b/python/tests/test_cpp_kernels.py
@@ -24,6 +24,7 @@ def compare_matrices(A: PETSc.Mat, B: PETSc.Mat, atol: float = 1e-13):
     A_sp = scipy.sparse.csr_matrix((av, aj, ai), shape=A.getSize())
     bi, bj, bv = B.getValuesCSR()
     B_sp = scipy.sparse.csr_matrix((bv, bj, bi), shape=B.getSize())
+
     # Compare matrices
     diff = np.abs(A_sp - B_sp)
     assert diff.max() <= atol
@@ -135,20 +136,60 @@ def test_surface_kernels(dim, kernel_type):
     compare_matrices(A, B)
 
 
-@pytest.mark.parametrize("kernel_type", [kt.Mass, kt.Stiffness, kt.TrEps])
+@pytest.mark.parametrize("kernel_type", [kt.Mass, kt.Stiffness])
 @pytest.mark.parametrize("P", [1, 2, 3, 4, 5])
 def test_volume_kernels(kernel_type, P):
     N = 4
     mesh = dolfinx.UnitCubeMesh(MPI.COMM_WORLD, N, N, N)
     # Define variational form
-    if kernel_type == kt.TrEps:
-        V = dolfinx.VectorFunctionSpace(mesh, ("CG", P))
+    V = dolfinx.FunctionSpace(mesh, ("CG", P))
+    bs = V.dofmap.index_map_bs
+
+    u = ufl.TrialFunction(V)
+    v = ufl.TestFunction(V)
+    dx = ufl.Measure("dx", domain=mesh)
+    if kernel_type == kt.Mass:
+        a = ufl.inner(u, v) * dx
+    elif kernel_type == kt.Stiffness:
+        a = ufl.inner(ufl.grad(u), ufl.grad(v)) * dx
     else:
-        V = dolfinx.FunctionSpace(mesh, ("CG", P))
+        raise RuntimeError("Unknown kernel")
+
+    # Compile UFL form
+    cffi_options = ["-Ofast", "-march=native"]
+    a = dolfinx.fem.Form(a, jit_parameters={"cffi_extra_compile_args": cffi_options, "cffi_libraries": ["m"]})
+    A = dolfinx.fem.create_matrix(a)
+
+    # Normal assembly
+    A.zeroEntries()
+    dolfinx.fem.assemble_matrix(A, a)
+    A.assemble()
+
+    # Custom assembly
+    num_local_cells = mesh.topology.index_map(mesh.topology.dim).size_local
+    active_cells = np.arange(num_local_cells, dtype=np.int32)
+    B = dolfinx.fem.create_matrix(a)
+    kernel = dolfinx_cuas.cpp.generate_kernel(kernel_type, P, bs)
+    B.zeroEntries()
+    dolfinx_cuas.cpp.assemble_cells(B, a._cpp_object, active_cells, kernel)
+    B.assemble()
+
+    # Compare matrices, first norm, then entries
+    assert np.isclose(A.norm(), B.norm())
+    compare_matrices(A, B)
+
+
+@pytest.mark.parametrize("kernel_type", [kt.TrEps])
+@pytest.mark.parametrize("P", [1, 2, 3, 4, 5])
+def test_vector_cell_kernel(kernel_type, P):
+    N = 1
+    mesh = dolfinx.UnitCubeMesh(MPI.COMM_WORLD, N, N, N)
+    V = dolfinx.VectorFunctionSpace(mesh, ("CG", P))
     bs = V.dofmap.index_map_bs
     u = ufl.TrialFunction(V)
     v = ufl.TestFunction(V)
     dx = ufl.Measure("dx", domain=mesh)
+
     if kernel_type == kt.Mass:
         a = ufl.inner(u, v) * dx
     elif kernel_type == kt.Stiffness:

--- a/python/tests/test_cpp_kernels.py
+++ b/python/tests/test_cpp_kernels.py
@@ -182,7 +182,7 @@ def test_volume_kernels(kernel_type, P):
 @pytest.mark.parametrize("kernel_type", [kt.TrEps, kt.SymGrad])
 @pytest.mark.parametrize("P", [1, 2, 3, 4, 5])
 def test_vector_cell_kernel(kernel_type, P):
-    N = 4
+    N = 5
     mesh = dolfinx.UnitCubeMesh(MPI.COMM_WORLD, N, N, N)
     V = dolfinx.VectorFunctionSpace(mesh, ("CG", P))
     bs = V.dofmap.index_map_bs


### PR DESCRIPTION
Added some new kernels:
- `2*ufl.inner(ufl.sym(ufl.grad(u)), ufl.sym(ufl.grad(v)) ) ufl.dx`
- `ufl.inner(ufl.tr(ufl.sym(ufl.grad(u))), ufl.sym(ufl.grad(v)) ) ufl.dx`
These matrices are required for elasticity and are the first assemblies supporting vector elements for cells.

New template parameter added to kernel generator for the block size (one for the existing cell kernels, three for current kernel).

Goal of next PR would be to support vector elements for all kernels and extend cell kernels to work for both 2D and 3D.

Some minor improvements to the C++ surface demo (CMake now runs ffcx). Also a fix to the 2D (unused) mesh generator in the surface demo.

Fix bug in matrix comparison which would make smaller matrices if last column/row is zero.