### PR TITLE
Add kernel using FacetNormals

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ See: `python/tests/test_cpp_kernels.py` for examples on how to interface with th
 
 See: `cpp/demo/main.cpp` for how to interface with the C++ layer.
 
-Currently implemented kernels for Lagrange elements (affine meshes):
+# Affine meshes (triangles and tetrahedra)
+## Lagrange elements (degree 1-5)
 - `ufl.inner(u, v) * ufl.dx` (3D)
 - `ufl.inner(u, v) * ufl.ds` (2D and 3D)
 - `ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx` (3D)
@@ -15,6 +16,11 @@ Currently implemented kernels for Lagrange elements (affine meshes):
 - `ufl.inner(ufl.tr(ufl.sym(ufl.grad(u))), ufl.sym(ufl.grad(v))) * ufl.dx` (3D)
 - `2 * ufl.inner(ufl.sym(ufl.grad(u)), ufl.sym(ufl.grad(v))) * ufl.dx` (3D)
 - `ufl.inner(ufl.sym(ufl.grad(u)), ufl.sym(ufl.grad(v))) * ufl.ds` (2D and 3D)
+- `2 * ufl.inner(ufl.sym(ufl.grad(u))) * ufl.FacetNormal(mesh), v) * ufl.ds` (2D and 3D)
+
+# Non-affine meshes (quadrilaterals and hexahedra)
+## Lagrange elements (degree 1-5)
+- `ufl.inner(u, v) * ufl.ds`
 
 ## Dependencies
 DOLFINX_CUAS depends on DOLFINx and in turn its dependencies.

--- a/cpp/kernels.hpp
+++ b/cpp/kernels.hpp
@@ -25,7 +25,8 @@ enum Kernel
   MassNonAffine,
   Stiffness,
   SymGrad,
-  TrEps
+  TrEps,
+  Normal
 };
 }
 
@@ -84,10 +85,9 @@ kernel_fn generate_tet_kernel(dolfinx_cuas::Kernel type)
       for (std::int32_t i = 0; i < ndofs_cell; i++)
         _dphi(q, i, k) = dphi(k, q, i);
 
-  kernel_fn stiffness
-      = [=](double* A, const double* c, const double* w, const double* coordinate_dofs,
-            const int* entity_local_index, const std::uint8_t* quadrature_permutation)
-  {
+  kernel_fn stiffness = [=](double* A, const double* c, const double* w,
+                            const double* coordinate_dofs, const int* entity_local_index,
+                            const std::uint8_t* quadrature_permutation) {
     // Get geometrical data
     xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
     xt::xtensor<double, 2> K = xt::zeros<double>({tdim, gdim});
@@ -130,8 +130,7 @@ kernel_fn generate_tet_kernel(dolfinx_cuas::Kernel type)
   // Mass Matrix using quadrature formulation
   // =====================================================================================
   kernel_fn mass = [=](double* A, const double* c, const double* w, const double* coordinate_dofs,
-                       const int* entity_local_index, const std::uint8_t* quadrature_permutation)
-  {
+                       const int* entity_local_index, const std::uint8_t* quadrature_permutation) {
     // Get geometrical data
     xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
     std::array<std::size_t, 2> shape = {d, gdim};
@@ -164,10 +163,9 @@ kernel_fn generate_tet_kernel(dolfinx_cuas::Kernel type)
       for (int j = 0; j < ndofs_cell; j++)
         A0(i, j) += weights[q] * phi(q, i) * phi(q, j);
 
-  kernel_fn masstensor
-      = [=](double* A, const double* c, const double* w, const double* coordinate_dofs,
-            const int* entity_local_index, const std::uint8_t* quadrature_permutation)
-  {
+  kernel_fn masstensor = [=](double* A, const double* c, const double* w,
+                             const double* coordinate_dofs, const int* entity_local_index,
+                             const std::uint8_t* quadrature_permutation) {
     // Get geometrical data
     xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
     std::array<std::size_t, 2> shape = {d, gdim};
@@ -185,8 +183,8 @@ kernel_fn generate_tet_kernel(dolfinx_cuas::Kernel type)
   // Tr(eps(u))I:eps(v) dx
   //========================================================================================
   kernel_fn tr_eps = [=](double* A, const double* c, const double* w, const double* coordinate_dofs,
-                         const int* entity_local_index, const std::uint8_t* quadrature_permutation)
-  {
+                         const int* entity_local_index,
+                         const std::uint8_t* quadrature_permutation) {
     assert(bs == 3);
     // Get geometrical data
     xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
@@ -236,10 +234,9 @@ kernel_fn generate_tet_kernel(dolfinx_cuas::Kernel type)
 
   // sym(grad(eps(u))):eps(v) dx
   //========================================================================================
-  kernel_fn sym_grad_eps
-      = [=](double* A, const double* c, const double* w, const double* coordinate_dofs,
-            const int* entity_local_index, const std::uint8_t* quadrature_permutation)
-  {
+  kernel_fn sym_grad_eps = [=](double* A, const double* c, const double* w,
+                               const double* coordinate_dofs, const int* entity_local_index,
+                               const std::uint8_t* quadrature_permutation) {
     assert(bs == 3);
     // Get geometrical data
     xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});

--- a/cpp/surface_kernels.hpp
+++ b/cpp/surface_kernels.hpp
@@ -33,7 +33,7 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
 
   // Create quadrature points on reference facet
   const basix::cell::type basix_facet = surface_element.cell_type();
-  auto [qp_ref_facet, qw_ref_facet]
+  auto [qp_ref_facet, q_weights]
       = basix::quadrature::make_quadrature("default", basix_facet, quadrature_degree);
 
   // Tabulate coordinate elemetn of reference facet (used to compute Jacobian on facet)
@@ -86,12 +86,11 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
   auto ref_jacobians = basix::cell::facet_jacobians(basix_element.cell_type());
 
   // Get facet normals on reference cell
-  auto facet_normals = basix::cell::facet_normals(basix_element.cell_type());
+  auto facet_normals = basix::cell::facet_outward_normals(basix_element.cell_type());
 
   // Define kernels
-  auto q_weights = qw_ref_facet;
   kernel_fn mass
-      = [facets, dphi_c, phi, gdim, tdim, fdim, bs, q_weights, num_coordinate_dofs,
+      = [dphi_c, phi, gdim, tdim, fdim, bs, q_weights, num_coordinate_dofs,
          ref_jacobians](double* A, const double* c, const double* w, const double* coordinate_dofs,
                         const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
@@ -148,7 +147,7 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
   };
 
   kernel_fn mass_nonaffine
-      = [facets, phi, dphi_c, gdim, tdim, fdim, bs, q_weights, num_coordinate_dofs,
+      = [phi, dphi_c, gdim, tdim, fdim, bs, q_weights, num_coordinate_dofs,
          ref_jacobians](double* A, const double* c, const double* w, const double* coordinate_dofs,
                         const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
@@ -202,7 +201,7 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
   };
   // FIXME: Template over gdim and tdim?
   kernel_fn stiffness
-      = [facets, dphi, gdim, tdim, fdim, bs, dphi_c, q_weights, num_coordinate_dofs,
+      = [dphi, gdim, tdim, fdim, bs, dphi_c, q_weights, num_coordinate_dofs,
          ref_jacobians](double* A, const double* c, const double* w, const double* coordinate_dofs,
                         const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
@@ -266,7 +265,7 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
   };
 
   kernel_fn sym_grad
-      = [facets, dphi, gdim, tdim, fdim, bs, dphi_c, q_weights, num_coordinate_dofs,
+      = [dphi, gdim, tdim, fdim, bs, dphi_c, q_weights, num_coordinate_dofs,
          ref_jacobians](double* A, const double* c, const double* w, const double* coordinate_dofs,
                         const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
@@ -342,7 +341,7 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
     }
   };
   kernel_fn normal
-      = [facets, dphi, gdim, tdim, fdim, bs, dphi_c, q_weights, num_coordinate_dofs, ref_jacobians,
+      = [dphi, gdim, tdim, fdim, bs, dphi_c, q_weights, num_coordinate_dofs, ref_jacobians,
          facet_normals](double* A, const double* c, const double* w, const double* coordinate_dofs,
                         const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {

--- a/cpp/surface_kernels.hpp
+++ b/cpp/surface_kernels.hpp
@@ -33,11 +33,13 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
 
   // Create quadrature points on reference facet
   const basix::cell::type basix_facet = surface_element.cell_type();
-  auto [qp_ref_facet, q_weights]
+  auto quadrature_data
       = basix::quadrature::make_quadrature("default", basix_facet, quadrature_degree);
+  auto qp_ref_facet = quadrature_data.first;
+  auto q_weights = quadrature_data.second;
 
-  // Tabulate coordinate elemetn of reference facet (used to compute Jacobian on facet)
-  // and push forward quadrature points
+  // Tabulate coordinate elemetn of reference facet (used to compute Jacobian on
+  // facet) and push forward quadrature points
   auto f_tab = surface_element.tabulate(0, qp_ref_facet);
   xt::xtensor<double, 2> phi_f = xt::view(f_tab, 0, xt::all(), xt::all(), 0);
 

--- a/python/dolfinx_cuas/wrappers.cpp
+++ b/python/dolfinx_cuas/wrappers.cpp
@@ -42,8 +42,7 @@ PYBIND11_MODULE(cpp, m)
                     std::shared_ptr<dolfinx::fem::FunctionSpace>>(),
            py::arg("marker"), py::arg("suface_0"), py::arg("surface_1"), py::arg("V"))
       .def("create_distance_map",
-           [](dolfinx_cuas::contact::Contact& self, int origin_meshtag)
-           {
+           [](dolfinx_cuas::contact::Contact& self, int origin_meshtag) {
              self.create_distance_map(origin_meshtag);
              return;
            })
@@ -51,39 +50,36 @@ PYBIND11_MODULE(cpp, m)
       .def("map_1_to_0", &dolfinx_cuas::contact::Contact::map_1_to_0)
       .def("facet_0", &dolfinx_cuas::contact::Contact::facet_0)
       .def("facet_1", &dolfinx_cuas::contact::Contact::facet_1);
-  m.def("generate_surface_kernel",
-        [](std::shared_ptr<const dolfinx::fem::FunctionSpace> V, dolfinx_cuas::Kernel type,
-           int quadrature_degree)
-        {
-          return cuas_wrappers::KernelWrapper(
-              dolfinx_cuas::generate_surface_kernel(V, type, quadrature_degree));
-        });
-  m.def("generate_kernel", [](dolfinx_cuas::Kernel type, int p, int bs)
-        { return cuas_wrappers::KernelWrapper(dolfinx_cuas::generate_kernel(type, p, bs)); });
+  m.def("generate_surface_kernel", [](std::shared_ptr<const dolfinx::fem::FunctionSpace> V,
+                                      dolfinx_cuas::Kernel type, int quadrature_degree) {
+    return cuas_wrappers::KernelWrapper(
+        dolfinx_cuas::generate_surface_kernel(V, type, quadrature_degree));
+  });
+  m.def("generate_kernel", [](dolfinx_cuas::Kernel type, int p, int bs) {
+    return cuas_wrappers::KernelWrapper(dolfinx_cuas::generate_kernel(type, p, bs));
+  });
   m.def("assemble_exterior_facets",
         [](Mat A, std::shared_ptr<const dolfinx::fem::Form<PetscScalar>> a,
            const py::array_t<std::int32_t, py::array::c_style>& active_facets,
-           cuas_wrappers::KernelWrapper& kernel)
-        {
+           cuas_wrappers::KernelWrapper& kernel) {
           auto ker = kernel.get();
           dolfinx_cuas::assemble_exterior_facets(
               dolfinx::la::PETScMatrix::set_block_fn(A, ADD_VALUES), a,
               xtl::span<const std::int32_t>(active_facets.data(), active_facets.size()), ker);
         });
-  m.def("assemble_cells",
-        [](Mat A, std::shared_ptr<const dolfinx::fem::Form<PetscScalar>> a,
-           const py::array_t<std::int32_t, py::array::c_style>& active_cells,
-           cuas_wrappers::KernelWrapper& kernel)
-        {
-          auto ker = kernel.get();
-          dolfinx_cuas::assemble_cells(
-              dolfinx::la::PETScMatrix::set_block_fn(A, ADD_VALUES), a,
-              xtl::span<const std::int32_t>(active_cells.data(), active_cells.size()), ker);
-        });
+  m.def("assemble_cells", [](Mat A, std::shared_ptr<const dolfinx::fem::Form<PetscScalar>> a,
+                             const py::array_t<std::int32_t, py::array::c_style>& active_cells,
+                             cuas_wrappers::KernelWrapper& kernel) {
+    auto ker = kernel.get();
+    dolfinx_cuas::assemble_cells(
+        dolfinx::la::PETScMatrix::set_block_fn(A, ADD_VALUES), a,
+        xtl::span<const std::int32_t>(active_cells.data(), active_cells.size()), ker);
+  });
   py::enum_<dolfinx_cuas::Kernel>(m, "Kernel")
       .value("Mass", dolfinx_cuas::Kernel::Mass)
       .value("MassNonAffine", dolfinx_cuas::Kernel::MassNonAffine)
       .value("Stiffness", dolfinx_cuas::Kernel::Stiffness)
       .value("SymGrad", dolfinx_cuas::Kernel::SymGrad)
-      .value("TrEps", dolfinx_cuas::Kernel::TrEps);
+      .value("TrEps", dolfinx_cuas::Kernel::TrEps)
+      .value("Normal", dolfinx_cuas::Kernel::Normal);
 }

--- a/python/tests/test_cpp_kernels.py
+++ b/python/tests/test_cpp_kernels.py
@@ -181,7 +181,7 @@ def test_normal_kernels(dim, kernel_type):
     B.assemble()
 
     # Compare matrices, first norm, then entries
-    # assert np.isclose(A.norm(), B.norm())
+    assert np.isclose(A.norm(), B.norm())
     compare_matrices(A, B)
 
 

--- a/python/tests/test_cpp_kernels.py
+++ b/python/tests/test_cpp_kernels.py
@@ -159,8 +159,7 @@ def test_normal_kernels(dim, kernel_type):
 
     # Define variational form
     V = dolfinx.VectorFunctionSpace(mesh, ("CG", 1))
-    from IPython import embed
-    embed()
+
     u = ufl.TrialFunction(V)
     v = ufl.TestFunction(V)
     ds = ufl.Measure("ds", domain=mesh, subdomain_data=ft)


### PR DESCRIPTION
We use the Covariant Piola map to transfer the FacetNormal to the physical domain (normalizing the transform).

Other minor simplifications