### PR TITLE
Add conts and coeffs as input to assembler

### DIFF
--- a/cpp/assembly.hpp
+++ b/cpp/assembly.hpp
@@ -23,40 +23,29 @@ namespace dolfinx_cuas
 void assemble_exterior_facets(
     const std::function<int(std::int32_t, const std::int32_t*, std::int32_t, const std::int32_t*,
                             const PetscScalar*)>& mat_set,
-    std::shared_ptr<const dolfinx::fem::Form<PetscScalar>> a,
-    const xtl::span<const std::int32_t>& active_facets, kernel_fn& kernel)
+    std::shared_ptr<dolfinx::fem::FunctionSpace> V,
+    const xtl::span<const std::int32_t>& active_facets, kernel_fn& kernel,
+    const dolfinx::array2d<PetscScalar>& coeffs, const xtl::span<const PetscScalar>& constants)
 {
   // Extract mesh
-  std::shared_ptr<const dolfinx::mesh::Mesh> mesh = a->function_spaces().at(0)->mesh();
+  std::shared_ptr<const dolfinx::mesh::Mesh> mesh = V->mesh();
 
-  // Extract function space data
-  std::shared_ptr<const dolfinx::fem::DofMap> dofmap0 = a->function_spaces().at(0)->dofmap();
-  std::shared_ptr<const dolfinx::fem::DofMap> dofmap1 = a->function_spaces().at(1)->dofmap();
-  const dolfinx::graph::AdjacencyList<std::int32_t>& dofs0 = dofmap0->list();
-  const int bs0 = dofmap0->bs();
-  const dolfinx::graph::AdjacencyList<std::int32_t>& dofs1 = dofmap1->list();
-  const int bs1 = dofmap1->bs();
-  std::vector<bool> bc0;
-  std::vector<bool> bc1;
-  std::shared_ptr<const dolfinx::fem::FiniteElement> element0
-      = a->function_spaces().at(0)->element();
-  std::shared_ptr<const dolfinx::fem::FiniteElement> element1
-      = a->function_spaces().at(1)->element();
+  // Extract function space data (assuming same test and trial space)
+  std::shared_ptr<const dolfinx::fem::DofMap> dofmap = V->dofmap();
+  const dolfinx::graph::AdjacencyList<std::int32_t>& dofs = dofmap->list();
+  const int bs = dofmap->bs();
+  std::vector<bool> bc;
+  std::shared_ptr<const dolfinx::fem::FiniteElement> element = V->element();
   const std::function<void(const xtl::span<double>&, const xtl::span<const std::uint32_t>&,
                            std::int32_t, int)>
-      apply_dof_transformation = element0->get_dof_transformation_function<double>();
+      apply_dof_transformation = element->get_dof_transformation_function<double>();
   const std::function<void(const xtl::span<double>&, const xtl::span<const std::uint32_t>&,
                            std::int32_t, int)>
       apply_dof_transformation_to_transpose
-      = element1->get_dof_transformation_to_transpose_function<double>();
+      = element->get_dof_transformation_to_transpose_function<double>();
 
-  // Pack constants and coefficients
-  const std::vector<double> constants = dolfinx::fem::pack_constants(*a);
-  const dolfinx::array2d<double> coeffs = dolfinx::fem::pack_coefficients(*a);
-
-  const bool needs_transformation_data = element0->needs_dof_transformations()
-                                         or element1->needs_dof_transformations()
-                                         or a->needs_facet_permutations();
+  // NOTE: Need to reconsider this when we get to jump integrals between disconnected interfaces
+  const bool needs_transformation_data = element->needs_dof_transformations();
 
   // Get permutation data
   xtl::span<const std::uint32_t> cell_info;
@@ -70,47 +59,37 @@ void assemble_exterior_facets(
 
   // Assemble using dolfinx
   dolfinx::fem::impl::assemble_exterior_facets<PetscScalar>(
-      mat_set, *mesh, active_facets, apply_dof_transformation, dofs0, bs0,
-      apply_dof_transformation_to_transpose, dofs1, bs1, bc0, bc1, kernel, coeffs, constants,
-      cell_info, perms);
+      mat_set, *mesh, active_facets, apply_dof_transformation, dofs, bs,
+      apply_dof_transformation_to_transpose, dofs, bs, bc, bc, kernel, coeffs, constants, cell_info,
+      perms);
 }
 
 void assemble_cells(const std::function<int(std::int32_t, const std::int32_t*, std::int32_t,
                                             const std::int32_t*, const PetscScalar*)>& mat_set,
-                    std::shared_ptr<const dolfinx::fem::Form<PetscScalar>> a,
-                    const xtl::span<const std::int32_t>& active_cells, kernel_fn& kernel)
+                    std::shared_ptr<dolfinx::fem::FunctionSpace> V,
+                    const xtl::span<const std::int32_t>& active_cells, kernel_fn& kernel,
+                    const dolfinx::array2d<PetscScalar>& coeffs,
+                    const xtl::span<const PetscScalar>& constants)
 {
   // Extract mesh
-  std::shared_ptr<const dolfinx::mesh::Mesh> mesh = a->function_spaces().at(0)->mesh();
+  std::shared_ptr<const dolfinx::mesh::Mesh> mesh = V->mesh();
 
   // Extract function space data
-  std::shared_ptr<const dolfinx::fem::DofMap> dofmap0 = a->function_spaces().at(0)->dofmap();
-  std::shared_ptr<const dolfinx::fem::DofMap> dofmap1 = a->function_spaces().at(1)->dofmap();
-  const dolfinx::graph::AdjacencyList<std::int32_t>& dofs0 = dofmap0->list();
-  const int bs0 = dofmap0->bs();
-  const dolfinx::graph::AdjacencyList<std::int32_t>& dofs1 = dofmap1->list();
-  const int bs1 = dofmap1->bs();
-  std::vector<bool> bc0;
-  std::vector<bool> bc1;
-  std::shared_ptr<const dolfinx::fem::FiniteElement> element0
-      = a->function_spaces().at(0)->element();
-  std::shared_ptr<const dolfinx::fem::FiniteElement> element1
-      = a->function_spaces().at(1)->element();
+  std::shared_ptr<const dolfinx::fem::DofMap> dofmap = V->dofmap();
+  const dolfinx::graph::AdjacencyList<std::int32_t>& dofs = dofmap->list();
+  const int bs = dofmap->bs();
+  std::vector<bool> bc;
+  std::shared_ptr<const dolfinx::fem::FiniteElement> element = V->element();
   const std::function<void(const xtl::span<double>&, const xtl::span<const std::uint32_t>&,
                            std::int32_t, int)>
-      apply_dof_transformation = element0->get_dof_transformation_function<double>();
+      apply_dof_transformation = element->get_dof_transformation_function<double>();
   const std::function<void(const xtl::span<double>&, const xtl::span<const std::uint32_t>&,
                            std::int32_t, int)>
       apply_dof_transformation_to_transpose
-      = element1->get_dof_transformation_to_transpose_function<double>();
+      = element->get_dof_transformation_to_transpose_function<double>();
 
-  // Pack constants and coefficients
-  const std::vector<double> constants = dolfinx::fem::pack_constants(*a);
-  const dolfinx::array2d<double> coeffs = dolfinx::fem::pack_coefficients(*a);
-
-  const bool needs_transformation_data = element0->needs_dof_transformations()
-                                         or element1->needs_dof_transformations()
-                                         or a->needs_facet_permutations();
+  // NOTE: Need to reconsider this when we get to jump integrals between disconnected interfaces
+  const bool needs_transformation_data = element->needs_dof_transformations();
 
   // Get permutation data
   xtl::span<const std::uint32_t> cell_info;
@@ -122,9 +101,9 @@ void assemble_cells(const std::function<int(std::int32_t, const std::int32_t*, s
 
   // Assemble using dolfinx
   dolfinx::fem::impl::assemble_cells<PetscScalar>(mat_set, mesh->geometry(), active_cells,
-                                                  apply_dof_transformation, dofs0, bs0,
-                                                  apply_dof_transformation_to_transpose, dofs1, bs1,
-                                                  bc0, bc1, kernel, coeffs, constants, cell_info);
+                                                  apply_dof_transformation, dofs, bs,
+                                                  apply_dof_transformation_to_transpose, dofs, bs,
+                                                  bc, bc, kernel, coeffs, constants, cell_info);
 }
 
 } // namespace dolfinx_cuas

--- a/cpp/demo/surface/main.cpp
+++ b/cpp/demo/surface/main.cpp
@@ -89,8 +89,11 @@ int main(int argc, char* argv[])
   la::PETScMatrix B = la::PETScMatrix(fem::create_matrix(*a), false);
   MatZeroEntries(B.mat());
   common::Timer t0("~Assemble Matrix Custom");
-  dolfinx_cuas::assemble_exterior_facets(la::PETScMatrix::set_block_fn(A.mat(), ADD_VALUES), a,
-                                         left_facets, kernel);
+  std::array<std::size_t, 2> shape = {std::size_t(ncells), 0};
+  const dolfinx::array2d<PetscScalar> coeffs(shape);
+  const std::vector<PetscScalar> consts(0);
+  dolfinx_cuas::assemble_exterior_facets(la::PETScMatrix::set_block_fn(A.mat(), ADD_VALUES), V,
+                                         left_facets, kernel, coeffs, consts);
   MatAssemblyBegin(A.mat(), MAT_FINAL_ASSEMBLY);
   MatAssemblyEnd(A.mat(), MAT_FINAL_ASSEMBLY);
   t0.stop();

--- a/cpp/demo/volume/main.cpp
+++ b/cpp/demo/volume/main.cpp
@@ -55,8 +55,11 @@ int main(int argc, char* argv[])
   xt::xarray<std::int32_t> active_cells = xt::arange<std::int32_t>(0, ncells);
 
   common::Timer t0("~Assemble Matrix Custom");
-  dolfinx_cuas::assemble_cells(la::PETScMatrix::set_block_fn(A.mat(), ADD_VALUES), a, active_cells,
-                               kernel);
+  std::array<std::size_t, 2> shape = {std::size_t(ncells), 0};
+  const dolfinx::array2d<PetscScalar> coeffs(shape);
+  const std::vector<PetscScalar> consts(0);
+  dolfinx_cuas::assemble_cells(la::PETScMatrix::set_block_fn(A.mat(), ADD_VALUES), V, active_cells,
+                               kernel, coeffs, consts);
   MatAssemblyBegin(A.mat(), MAT_FINAL_ASSEMBLY);
   MatAssemblyEnd(A.mat(), MAT_FINAL_ASSEMBLY);
   t0.stop();


### PR DESCRIPTION
Starts addressing #45 by making coeffs and consts user-input.