### PR TITLE
Custom pack_coefficients

### DIFF
--- a/cpp/utils.hpp
+++ b/cpp/utils.hpp
@@ -130,7 +130,12 @@ bool allclose(Mat A, Mat B)
   return xt::allclose(_A, _B);
 }
 
-// Pack coefficients
+/// Prepare coefficients (dolfinx.Function's) for assembly with custom kernels
+/// by packing them as a 2D array, where the ith row maps to the ith local cell.
+/// For each row, the first N_0 columns correspond to the values of the 0th function space with N_0
+/// dofs. If function space is blocked, the coefficients are ordered in XYZ XYZ ordering.
+/// @param[in] coeffs The coefficients to pack
+/// @param[out] c The packed coefficients
 dolfinx::array2d<PetscScalar>
 pack_coefficients(std::vector<std::shared_ptr<const dolfinx::fem::Function<PetscScalar>>> coeffs)
 {

--- a/cpp/utils.hpp
+++ b/cpp/utils.hpp
@@ -10,7 +10,12 @@
 #include <basix/cell.h>
 #include <basix/finite-element.h>
 #include <basix/quadrature.h>
+#include <dolfinx/common/IndexMap.h>
+#include <dolfinx/fem/DofMap.h>
+#include <dolfinx/fem/FiniteElement.h>
+#include <dolfinx/fem/Function.h>
 #include <dolfinx/fem/petsc.h>
+#include <dolfinx/fem/utils.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <xtensor-blas/xlinalg.hpp>
 
@@ -125,4 +130,89 @@ bool allclose(Mat A, Mat B)
   return xt::allclose(_A, _B);
 }
 
+// Pack coefficients
+dolfinx::array2d<PetscScalar>
+pack_coefficients(std::vector<std::shared_ptr<const dolfinx::fem::Function<PetscScalar>>> coeffs)
+{
+  // Coefficient offsets
+  std::vector<int> coeffs_offsets{0};
+  for (const auto& c : coeffs)
+  {
+    if (!c)
+      throw std::runtime_error("Not all form coefficients have been set.");
+    coeffs_offsets.push_back(coeffs_offsets.back()
+                             + c->function_space()->element()->space_dimension());
+  }
+
+  std::vector<const dolfinx::fem::DofMap*> dofmaps(coeffs.size());
+  std::vector<const dolfinx::fem::FiniteElement*> elements(coeffs.size());
+  std::vector<std::reference_wrapper<const std::vector<PetscScalar>>> v;
+  v.reserve(coeffs.size());
+  for (std::size_t i = 0; i < coeffs.size(); ++i)
+  {
+    elements[i] = coeffs[i]->function_space()->element().get();
+    dofmaps[i] = coeffs[i]->function_space()->dofmap().get();
+    v.push_back(coeffs[i]->x()->array());
+  }
+
+  // Get mesh
+  std::shared_ptr<const dolfinx::mesh::Mesh> mesh = coeffs[0]->function_space()->mesh();
+  assert(mesh);
+  const int tdim = mesh->topology().dim();
+  const std::int32_t num_cells = mesh->topology().index_map(tdim)->size_local()
+                                 + mesh->topology().index_map(tdim)->num_ghosts();
+
+  // Copy data into coefficient array
+  dolfinx::array2d<PetscScalar> c(num_cells, coeffs_offsets.back());
+  if (!coeffs.empty())
+  {
+    bool needs_dof_transformations = false;
+    for (std::size_t coeff = 0; coeff < dofmaps.size(); ++coeff)
+    {
+      if (elements[coeff]->needs_dof_transformations())
+      {
+        needs_dof_transformations = true;
+        mesh->topology_mutable().create_entity_permutations();
+      }
+    }
+
+    // Iterate over coefficients
+    xtl::span<const std::uint32_t> cell_info;
+    if (needs_dof_transformations)
+      cell_info = xtl::span(mesh->topology().get_cell_permutation_info());
+    for (std::size_t coeff = 0; coeff < dofmaps.size(); ++coeff)
+    {
+      const std::function<void(const xtl::span<PetscScalar>&, const xtl::span<const std::uint32_t>&,
+                               std::int32_t, int)>
+          transformation
+          = elements[coeff]->get_dof_transformation_function<PetscScalar>(false, true);
+      if (int bs = dofmaps[coeff]->bs(); bs == 1)
+      {
+        dolfinx::fem::impl::pack_coefficient<PetscScalar, 1>(
+            c, v[coeff], cell_info, *dofmaps[coeff], num_cells, coeffs_offsets[coeff],
+            elements[coeff]->space_dimension(), transformation);
+      }
+      else if (bs == 2)
+      {
+        dolfinx::fem::impl::pack_coefficient<PetscScalar, 2>(
+            c, v[coeff], cell_info, *dofmaps[coeff], num_cells, coeffs_offsets[coeff],
+            elements[coeff]->space_dimension(), transformation);
+      }
+      else if (bs == 3)
+      {
+        dolfinx::fem::impl::pack_coefficient<PetscScalar, 3>(
+            c, v[coeff], cell_info, *dofmaps[coeff], num_cells, coeffs_offsets[coeff],
+            elements[coeff]->space_dimension(), transformation);
+      }
+      else
+      {
+        dolfinx::fem::impl::pack_coefficient<PetscScalar>(
+            c, v[coeff], cell_info, *dofmaps[coeff], num_cells, coeffs_offsets[coeff],
+            elements[coeff]->space_dimension(), transformation);
+      }
+    }
+  }
+
+  return c;
+}
 } // namespace dolfinx_cuas

--- a/python/dolfinx_cuas/array.h
+++ b/python/dolfinx_cuas/array.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
+#include <dolfinx/common/array2d.h>
 #include <memory>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 
-namespace dolfinx_mpc_wrappers
+namespace dolfinx_cuas_wrappers
 {
 
 /// Create a py::array_t that shares data with a std::vector. The
@@ -31,4 +32,23 @@ inline py::array_t<typename Sequence::value_type> as_pyarray(Sequence&& seq)
   return py::array(size, data, capsule);
 }
 
-} // namespace dolfinx_mpc_wrappers
+/// Create a py::array_t that shares data with a
+/// dolfinx::array2d. The C++ array2d owns the data, and the
+/// py::array_t object keeps the C++ object alive .
+// From https://github.com/pybind/pybind11/issues/1042
+template <typename T>
+inline py::array_t<T> as_pyarray2d(dolfinx::array2d<T>&& array)
+{
+  auto shape = array.shape;
+  auto strides = array.strides();
+  auto data = array.data();
+  std::unique_ptr<dolfinx::array2d<T>> array_ptr
+      = std::make_unique<dolfinx::array2d<T>>(std::move(array));
+  auto capsule = py::capsule(
+      array_ptr.get(), [](void* p)
+      { std::unique_ptr<dolfinx::array2d<T>>(reinterpret_cast<dolfinx::array2d<T>*>(p)); });
+  array_ptr.release();
+  return py::array(shape, strides, data, capsule);
+}
+
+} // namespace dolfinx_cuas_wrappers

--- a/python/dolfinx_cuas/wrappers.cpp
+++ b/python/dolfinx_cuas/wrappers.cpp
@@ -90,6 +90,10 @@ PYBIND11_MODULE(cpp, m)
               xtl::span<const std::int32_t>(active_cells.data(), active_cells.size()), ker, _coeffs,
               xtl::span(constants.data(), constants.shape(0)));
         });
+  m.def("pack_coefficients",
+        [](std::vector<std::shared_ptr<const dolfinx::fem::Function<PetscScalar>>> coeffs)
+        { return dolfinx_cuas_wrappers::as_pyarray2d(dolfinx_cuas::pack_coefficients(coeffs)); });
+
   py::enum_<dolfinx_cuas::Kernel>(m, "Kernel")
       .value("Mass", dolfinx_cuas::Kernel::Mass)
       .value("MassNonAffine", dolfinx_cuas::Kernel::MassNonAffine)

--- a/python/tests/test_coeffs.py
+++ b/python/tests/test_coeffs.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2021 Jørgen S. Dokken
+#
+# SPDX-License-Identifier:   LGPL-3.0-or-later
+
+import dolfinx
+import dolfinx_cuas.cpp
+import numpy as np
+import ufl
+from mpi4py import MPI
+
+
+def test_pack_coeffs():
+    mesh = dolfinx.UnitSquareMesh(MPI.COMM_WORLD, 10, 10)
+    V = dolfinx.VectorFunctionSpace(mesh, ("CG", 2))
+    Q = dolfinx.VectorFunctionSpace(mesh, ("DG", 1))
+    Z = dolfinx.FunctionSpace(mesh, ("DG", 0))
+    v = dolfinx.Function(V)
+    q = dolfinx.Function(Q)
+    z = dolfinx.Function(Z)
+    a = z * ufl.inner(v, z * q) * ufl.dx
+    form = dolfinx.Form(a)._cpp_object
+    coeffs = dolfinx.cpp.fem.pack_coefficients(form)
+    coeffs_cuas = dolfinx_cuas.cpp.pack_coefficients(form.coefficients)
+    assert np.allclose(coeffs, coeffs_cuas)


### PR DESCRIPTION
As the custom assemblers are not based on a form, we need to pack coefficients manually, by specifying a list of functions that should be packed.

This PR adds this functionality (based on dolfinx implementation).