### PR TITLE
Rewrite quadrature class to simplify generation of element kernels

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Set project name and version number
-project(DOLFINX_CUAS VERSION 0.1.1.0)
+project(DOLFINX_CUAS VERSION 0.3.1.0)
 
 #------------------------------------------------------------------------------
 # Set CMake options, see `cmake --help-policy CMP00xx`
@@ -42,9 +42,8 @@ add_feature_info(CMAKE_INSTALL_RPATH_USE_LINK_PATH CMAKE_INSTALL_RPATH_USE_LINK_
 
 # Find packages
 find_package(DOLFINX 0.3.1.0 REQUIRED)
-find_package(Basix 0.1.1.0 REQUIRED)
+find_package(Basix 0.3.1.0 REQUIRED)
 find_package(xtensor REQUIRED)
-find_package(xtensor-blas REQUIRED)
 
 feature_summary(WHAT ALL)
 

--- a/cpp/QuadratureRule.hpp
+++ b/cpp/QuadratureRule.hpp
@@ -7,59 +7,125 @@
 
 #pragma once
 
+#include <basix/finite-element.h>
 #include <basix/quadrature.h>
 #include <dolfinx/mesh/cell_types.h>
 #include <dolfinx/mesh/utils.h>
+#include <xtensor-blas/xlinalg.hpp>
 #include <xtensor/xadapt.hpp>
-#include <xtensor/xio.hpp>
+#include <xtensor/xarray.hpp>
+
 namespace dolfinx_cuas
 {
 
 class QuadratureRule
 {
-  // Contains quadrature points and weights.
+  // Contains quadrature points and weights on a cell on a set of entities
 
 public:
   /// Constructor
   /// @param[in] ct The cell type
   /// @param[in] degree Degree of quadrature rule
+  /// @param[in] Dimension of entity
   /// @param[in] type Type of quadrature rule
-  QuadratureRule(dolfinx::mesh::CellType ct, int degree, std::string type = "default")
+  QuadratureRule(dolfinx::mesh::CellType ct, int degree, int dim, std::string type = "default")
+      : _cell_type(ct), _degree(degree), _type(type), _dim(dim)
   {
-    std::pair<xt::xarray<double>, std::vector<double>> quadrature
-        = basix::quadrature::make_quadrature(type, dolfinx::mesh::cell_type_to_basix_type(ct),
-                                             degree);
-    // NOTE: Conversion could be easier if return-type had been nicer from Basix
-    // Currently we need to determine the dimension of the quadrature rule and reshape data
-    // accordingly
-    if (quadrature.first.dimension() == 1)
-      _points = xt::empty<double>({quadrature.first.shape(0)});
-    else
-      _points = xt::empty<double>({quadrature.first.shape(0), quadrature.first.shape(1)});
-    for (std::size_t i = 0; i < quadrature.first.size(); i++)
-      _points[i] = quadrature.first[i];
 
-    _weights = xt::adapt(quadrature.second);
+    basix::cell::type b_ct = dolfinx::mesh::cell_type_to_basix_type(ct);
+    const int num_entities = basix::cell::num_sub_entities(b_ct, dim);
+    _points.reserve(num_entities);
+    _weights.reserve(num_entities);
+
+    const int tdim = basix::cell::topological_dimension(b_ct);
+
+    // If cell dimension no pushing forward
+    if (tdim == dim)
+    {
+      std::pair<xt::xarray<double>, std::vector<double>> quadrature
+          = basix::quadrature::make_quadrature(type, b_ct, degree);
+      // NOTE: Conversion could be easier if return-type had been nicer from Basix
+      // Currently we need to determine the dimension of the quadrature rule and reshape data
+      // accordingly
+      xt::xarray<double> points;
+      if (quadrature.first.dimension() == 1)
+        points = xt::empty<double>({quadrature.first.shape(0)});
+      else
+        points = xt::empty<double>({quadrature.first.shape(0), quadrature.first.shape(1)});
+      for (std::size_t i = 0; i < quadrature.first.size(); i++)
+        points[i] = quadrature.first[i];
+      for (std::int32_t i = 0; i < num_entities; i++)
+      {
+        _points.push_back(points);
+        _weights.push_back(quadrature.second);
+      }
+    }
+    else
+    {
+      // Create reference topology and geometry
+      auto entity_topology = basix::cell::topology(b_ct)[dim];
+      const xt::xtensor<double, 2> ref_geom = basix::cell::geometry(b_ct);
+
+      // Create map for each facet type to the local index
+      for (std::int32_t i = 0; i < num_entities; i++)
+      {
+        // FIXME: Support higher order cmap
+        // NOTE: Not sure we need a higher order coordinate element, as reference facets
+        // and cell is affine
+        const int e_degree = 1;
+        basix::cell::type et = basix::cell::sub_entity_type(b_ct, dim, i);
+        basix::FiniteElement entity_element = basix::create_element(
+            basix::element::family::P, et, e_degree, basix::element::lagrange_variant::equispaced);
+
+        // Create quadrature and tabulate on entity
+        std::pair<xt::xarray<double>, std::vector<double>> quadrature
+            = basix::quadrature::make_quadrature("default", et, degree);
+        auto c_tab = entity_element.tabulate(0, quadrature.first);
+        xt::xtensor<double, 2> phi_s = xt::view(c_tab, 0, xt::all(), xt::all(), 0);
+
+        auto cell_entity = entity_topology[i];
+        auto coords = xt::view(ref_geom, xt::keep(cell_entity), xt::all());
+
+        // Push forward quadrature point from reference entity to reference entity on cell
+        _weights.push_back(quadrature.second);
+        const std::uint32_t num_quadrature_pts = quadrature.first.shape(0);
+        _points.push_back(xt::xtensor<double, 3>({num_quadrature_pts, ref_geom.shape(1)}));
+        _points[i] = xt::linalg::dot(phi_s, coords);
+      }
+    }
+  }
+  /// Return quadrature points
+  std::vector<xt::xarray<double>>& points_ref() { return _points; }
+
+  /// Return quadrature weights
+  std::vector<std::vector<double>>& weights_ref() { return _weights; }
+
+  /// Return quadrature points
+  std::vector<xt::xarray<double>> points() { return _points; }
+
+  /// Return quadrature weights
+  std::vector<std::vector<double>> weights() { return _weights; }
+
+  /// Return quadrature weights
+  int dim() { return _dim; }
+
+  /// Return the cell type for the ith quadrature rule
+  /// @param[in] Local entity number
+  dolfinx::mesh::CellType cell_type(int i)
+  {
+    basix::cell::type b_ct = dolfinx::mesh::cell_type_to_basix_type(_cell_type);
+    assert(i < basix::cell::num_sub_entities(b_ct, _dim));
+    basix::cell::type et = basix::cell::sub_entity_type(b_ct, _dim, i);
+    return dolfinx::mesh::cell_type_from_basix_type(et);
   }
 
-  /// Return quadrature points
-  xt::xarray<double>& points_ref() { return _points; }
-
-  /// Return quadrature weights
-  xt::xarray<double>& weights_ref() { return _weights; }
-
-  /// Return quadrature points
-  xt::xarray<double> points() { return _points; }
-
-  /// Return quadrature weights
-  xt::xarray<double> weights() { return _weights; }
-
-  /// Return number of quadrature points
-  std::size_t num_points() { return _points.size(); }
-
 private:
-  xt::xarray<double> _points;  // 2D array of quadrature points
-  xt::xarray<double> _weights; // 1D array of quadrature weights
+  dolfinx::mesh::CellType _cell_type;
+  int _degree;
+  std::string _type;
+  int _dim;
+  std::vector<xt::xarray<double>> _points;   // Quadrature points for each entity on the cell
+  std::vector<std::vector<double>> _weights; // Quadrature weights for each entity on the cell
 };
 
 } // namespace dolfinx_cuas

--- a/cpp/QuadratureRule.hpp
+++ b/cpp/QuadratureRule.hpp
@@ -7,11 +7,11 @@
 
 #pragma once
 
+#include "math.hpp"
 #include <basix/finite-element.h>
 #include <basix/quadrature.h>
 #include <dolfinx/mesh/cell_types.h>
 #include <dolfinx/mesh/utils.h>
-#include <xtensor-blas/xlinalg.hpp>
 #include <xtensor/xadapt.hpp>
 #include <xtensor/xarray.hpp>
 
@@ -88,9 +88,11 @@ public:
 
         // Push forward quadrature point from reference entity to reference entity on cell
         _weights.push_back(quadrature.second);
-        const std::uint32_t num_quadrature_pts = quadrature.first.shape(0);
-        _points.push_back(xt::xtensor<double, 3>({num_quadrature_pts, ref_geom.shape(1)}));
-        _points[i] = xt::linalg::dot(phi_s, coords);
+        const size_t num_quadrature_pts = quadrature.first.shape(0);
+        xt::xarray<double> zeros
+            = xt::zeros<double>({num_quadrature_pts, static_cast<std::size_t>(ref_geom.shape(1))});
+        dolfinx::math::dot(phi_s, coords, zeros);
+        _points.push_back(zeros);
       }
     }
   }

--- a/cpp/QuadratureRule.hpp
+++ b/cpp/QuadratureRule.hpp
@@ -89,10 +89,10 @@ public:
         // Push forward quadrature point from reference entity to reference entity on cell
         _weights.push_back(quadrature.second);
         const size_t num_quadrature_pts = quadrature.first.shape(0);
-        xt::xarray<double> zeros
+        xt::xarray<double> entity_qp
             = xt::zeros<double>({num_quadrature_pts, static_cast<std::size_t>(ref_geom.shape(1))});
-        dolfinx::math::dot(phi_s, coords, zeros);
-        _points.push_back(zeros);
+        dolfinx::math::dot(phi_s, coords, entity_qp);
+        _points.push_back(entity_qp);
       }
     }
   }

--- a/cpp/QuadratureRule.hpp
+++ b/cpp/QuadratureRule.hpp
@@ -96,19 +96,23 @@ public:
       }
     }
   }
-  /// Return quadrature points
+  /// Return a list of quadrature points for each entity in the cell (using local entity index as in
+  /// DOLFINx/Basix)
   std::vector<xt::xarray<double>>& points_ref() { return _points; }
 
-  /// Return quadrature weights
+  /// Return a list of quadrature weights for each entity in the cell (using local entity index as
+  /// in DOLFINx/Basix)
   std::vector<std::vector<double>>& weights_ref() { return _weights; }
 
-  /// Return quadrature points
+  /// Return a list of quadrature points for each entity in the cell (using local entity index as in
+  /// DOLFINx/Basix)
   std::vector<xt::xarray<double>> points() { return _points; }
 
-  /// Return quadrature weights
+  /// Return a list of quadrature weights for each entity in the cell (using local entity index as
+  /// in DOLFINx/Basix)
   std::vector<std::vector<double>> weights() { return _weights; }
 
-  /// Return quadrature weights
+  /// Return dimension of entity in the quadrature rule
   int dim() { return _dim; }
 
   /// Return the cell type for the ith quadrature rule

--- a/cpp/demo/surface/CMakeLists.txt
+++ b/cpp/demo/surface/CMakeLists.txt
@@ -12,7 +12,6 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 find_package(DOLFINX REQUIRED)
 find_package(Basix REQUIRED)
 find_package(xtensor REQUIRED)
-find_package(xtensor-blas REQUIRED)
 
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/problem.c

--- a/cpp/demo/surface/main.cpp
+++ b/cpp/demo/surface/main.cpp
@@ -46,10 +46,7 @@ int main(int argc, char* argv[])
   // Generate boundary kernel
   const std::int32_t tdim = mesh->topology().dim();
 
-  // NOTE: Does not work for prism meshes
-  dolfinx::mesh::CellType facet_type
-      = dolfinx::mesh::cell_entity_type(mesh->topology().cell_type(), tdim - 1, 0);
-  dolfinx_cuas::QuadratureRule q_rule(facet_type, 2 * (Q - 1));
+  dolfinx_cuas::QuadratureRule q_rule(mesh->topology().cell_type(), 2 * (Q - 1), tdim - 1);
   auto kernel = dolfinx_cuas::generate_surface_kernel(V, dolfinx_cuas::Kernel::SymGrad, q_rule);
 
   // Define variational forms

--- a/cpp/demo/volume/CMakeLists.txt
+++ b/cpp/demo/volume/CMakeLists.txt
@@ -11,7 +11,6 @@ set(CMAKE_C_FLAGS "-Ofast -march=native ${CMAKE_C_FLAGS} -Wall")
 find_package(DOLFINX REQUIRED)
 find_package(Basix REQUIRED)
 find_package(xtensor REQUIRED)
-find_package(xtensor-blas REQUIRED)
 
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.c

--- a/cpp/demo/volume/main.cpp
+++ b/cpp/demo/volume/main.cpp
@@ -26,9 +26,8 @@ int main(int argc, char* argv[])
 
   po::options_description desc("Allowed options");
   desc.add_options()("help,h", "print usage message")(
-      "kernel", po::value<std::string>()->default_value("mass"),
-      "kernel (mass or stiffness)")("degree", po::value<int>()->default_value(1),
-                                    "Degree of function space (1-5)");
+      "kernel", po::value<std::string>()->default_value("mass"), "kernel (mass or stiffness)")(
+      "degree", po::value<int>()->default_value(1), "Degree of function space (1-5)");
   po::variables_map vm;
   po::store(po::command_line_parser(argc, argv).options(desc).run(), vm);
   po::notify(vm);
@@ -97,7 +96,8 @@ int main(int argc, char* argv[])
   MatZeroEntries(B.mat());
 
   // Generate Kernel
-  dolfinx_cuas::QuadratureRule q_rule(mesh->topology().cell_type(), q_degree, "default");
+  dolfinx_cuas::QuadratureRule q_rule(mesh->topology().cell_type(), q_degree,
+                                      mesh->topology().dim(), "default");
   auto kernel
       = dolfinx_cuas::generate_kernel(kernel_type, degree, V->dofmap()->index_map_bs(), q_rule);
 

--- a/cpp/kernels.hpp
+++ b/cpp/kernels.hpp
@@ -50,8 +50,8 @@ kernel_fn generate_tet_kernel(dolfinx_cuas::Kernel type,
   constexpr std::int32_t d = 4;
   constexpr std::int32_t ndofs_cell = (P + 1) * (P + 2) * (P + 3) / 6;
 
-  xt::xarray<double>& weights = quadrature_rule.weights_ref();
-  xt::xarray<double>& points = quadrature_rule.points_ref();
+  std::vector<double>& weights = quadrature_rule.weights_ref()[0];
+  xt::xarray<double>& points = quadrature_rule.points_ref()[0];
 
   // Create Finite element for test and trial functions and tabulate shape functions
   basix::FiniteElement element

--- a/cpp/kernels.hpp
+++ b/cpp/kernels.hpp
@@ -12,7 +12,6 @@
 #include <basix/finite-element.h>
 #include <basix/quadrature.h>
 #include <string>
-#include <xtensor-blas/xlinalg.hpp>
 
 using kernel_fn = std::function<void(double*, const double*, const double*, const double*,
                                      const int*, const std::uint8_t*)>;
@@ -89,9 +88,10 @@ kernel_fn generate_tet_kernel(dolfinx_cuas::Kernel type,
     xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
     xt::xtensor<double, 2> K = xt::zeros<double>({tdim, gdim});
     xt::xtensor<double, 2> coord = xt::adapt(coordinate_dofs, gdim * d, xt::no_ownership(), shape);
+    auto c_view = xt::view(coord, xt::all(), xt::range(0, gdim));
 
     // Compute Jacobian, its inverse and the determinant
-    dolfinx_cuas::math::compute_jacobian(dphi0_c, coord, J);
+    dolfinx_cuas::math::compute_jacobian(dphi0_c, c_view, J);
     dolfinx_cuas::math::compute_inv(J, K);
     const double detJ = std::fabs(dolfinx_cuas::math::compute_determinant(J));
 
@@ -146,9 +146,10 @@ kernel_fn generate_tet_kernel(dolfinx_cuas::Kernel type,
     xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
     std::array<std::size_t, 2> shape = {d, gdim};
     xt::xtensor<double, 2> coord = xt::adapt(coordinate_dofs, gdim * d, xt::no_ownership(), shape);
+    auto c_view = xt::view(coord, xt::all(), xt::range(0, gdim));
 
     // Compute Jacobian, its inverse and the determinant
-    dolfinx_cuas::math::compute_jacobian(dphi0_c, coord, J);
+    dolfinx_cuas::math::compute_jacobian(dphi0_c, c_view, J);
     double detJ = std::fabs(dolfinx_cuas::math::compute_determinant(J));
 
     // Main loop
@@ -189,9 +190,10 @@ kernel_fn generate_tet_kernel(dolfinx_cuas::Kernel type,
     xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
     std::array<std::size_t, 2> shape = {d, gdim};
     xt::xtensor<double, 2> coord = xt::adapt(coordinate_dofs, gdim * d, xt::no_ownership(), shape);
+    auto c_view = xt::view(coord, xt::all(), xt::range(0, gdim));
 
     // Compute Jacobian, its inverse and the determinant
-    dolfinx_cuas::math::compute_jacobian(dphi0_c, coord, J);
+    dolfinx_cuas::math::compute_jacobian(dphi0_c, c_view, J);
     double detJ = std::fabs(dolfinx_cuas::math::compute_determinant(J));
 
     for (int i = 0; i < ndofs_cell; i++)
@@ -212,7 +214,8 @@ kernel_fn generate_tet_kernel(dolfinx_cuas::Kernel type,
     xt::xtensor<double, 2> coord = xt::adapt(coordinate_dofs, gdim * d, xt::no_ownership(), shape);
 
     // Compute Jacobian, its inverse and the determinant
-    dolfinx_cuas::math::compute_jacobian(dphi0_c, coord, J);
+    auto c_view = xt::view(coord, xt::all(), xt::range(0, gdim));
+    dolfinx_cuas::math::compute_jacobian(dphi0_c, c_view, J);
     dolfinx_cuas::math::compute_inv(J, K);
     double detJ = std::fabs(dolfinx_cuas::math::compute_determinant(J));
 
@@ -265,7 +268,8 @@ kernel_fn generate_tet_kernel(dolfinx_cuas::Kernel type,
     xt::xtensor<double, 2> coord = xt::adapt(coordinate_dofs, gdim * d, xt::no_ownership(), shape);
 
     // Compute Jacobian, its inverse and the determinant
-    dolfinx_cuas::math::compute_jacobian(dphi0_c, coord, J);
+    auto c_view = xt::view(coord, xt::all(), xt::range(0, gdim));
+    dolfinx_cuas::math::compute_jacobian(dphi0_c, c_view, J);
     dolfinx_cuas::math::compute_inv(J, K);
     double detJ = std::fabs(dolfinx_cuas::math::compute_determinant(J));
 

--- a/cpp/kernels_non_const_coefficient.hpp
+++ b/cpp/kernels_non_const_coefficient.hpp
@@ -37,8 +37,9 @@ kernel_fn generate_coefficient_kernel(
   constexpr std::int32_t d = 4;
   constexpr std::int32_t ndofs_cell = (P + 1) * (P + 2) * (P + 3) / 6;
 
-  xt::xarray<double>& points = q_rule.points_ref();
-  xt::xarray<double>& weights = q_rule.weights_ref();
+  // Get quadrature points and quadrature weights
+  std::vector<double>& weights = q_rule.weights_ref()[0];
+  xt::xarray<double>& points = q_rule.points_ref()[0];
 
   // Create Finite element for test and trial functions and tabulate shape functions
   basix::FiniteElement element

--- a/cpp/kernels_non_const_coefficient.hpp
+++ b/cpp/kernels_non_const_coefficient.hpp
@@ -11,7 +11,6 @@
 #include <basix/quadrature.h>
 #include <dolfinx/fem/Function.h>
 #include <string>
-#include <xtensor-blas/xlinalg.hpp>
 
 #include "math.hpp"
 

--- a/cpp/math.hpp
+++ b/cpp/math.hpp
@@ -7,103 +7,26 @@
 #pragma once
 
 #include <cmath>
-#include <xtensor-blas/xlinalg.hpp>
-namespace
-{
-/// Kahan’s method to compute x = ad − bc with fused multiply-adds.
-/// The absolute error is bounded by 1.5 ulps, units of least precision.
-template <typename T>
-inline T difference_of_products(T a, T b, T c, T d) noexcept
-{
-  T w = b * c;
-  T err = std::fma(-b, c, w);
-  T diff = std::fma(a, d, -w);
-  return (diff + err);
-}
-/// Compute the determinant of a small matrix (1x1, 2x2, or 3x3).
-/// Tailored for use in computations using the Jacobian.
-template <typename Matrix>
-auto det(const Matrix& A)
-{
-  using value_type = typename Matrix::value_type;
-  assert(A.shape(0) == A.shape(1));
-  assert(A.dimension() == 2);
+#include <dolfinx/common/math.h>
 
-  const int nrows = A.shape(0);
-  switch (nrows)
-  {
-  case 1:
-    return A(0, 0);
-  case 2:
-    return difference_of_products(A(0, 0), A(0, 1), A(1, 0), A(1, 1));
-  case 3:
-  {
-    // Leibniz formula combined with Kahan’s method for accurate
-    // computation of 3 x 3 determinants
-    value_type w0 = difference_of_products(A(1, 1), A(1, 2), A(2, 1), A(2, 2));
-    value_type w1 = difference_of_products(A(1, 0), A(1, 2), A(2, 0), A(2, 2));
-    value_type w2 = difference_of_products(A(1, 0), A(1, 1), A(2, 0), A(2, 1));
-    value_type w3 = difference_of_products(A(0, 0), A(0, 1), w1, w0);
-    value_type w4 = std::fma(A(0, 2), w2, w3);
-    return w4;
-  }
-  default:
-    throw std::runtime_error("math::det is not implemented for " + std::to_string(A.shape(0)) + "x"
-                             + std::to_string(A.shape(1)) + " matrices.");
-  }
-}
-
-/// Compute the inverse of a square matrix A and assign the result to a
-/// preallocated matrix B.
-/// @warning This function does not check if A is invertible!
-template <typename U, typename V>
-void inv(const U& A, V& B)
-{
-  using value_type = typename U::value_type;
-  const int nrows = A.shape(0);
-  switch (nrows)
-  {
-  case 1:
-    B(0, 0) = 1 / A(0, 0);
-    break;
-  case 2:
-  {
-    value_type idet = 1. / det(A);
-    B(0, 0) = idet * A(1, 1);
-    B(0, 1) = -idet * A(0, 1);
-    B(1, 0) = -idet * A(1, 0);
-    B(1, 1) = idet * A(0, 0);
-    break;
-  }
-  case 3:
-  {
-    value_type w0 = difference_of_products(A(1, 1), A(1, 2), A(2, 1), A(2, 2));
-    value_type w1 = difference_of_products(A(1, 0), A(1, 2), A(2, 0), A(2, 2));
-    value_type w2 = difference_of_products(A(1, 0), A(1, 1), A(2, 0), A(2, 1));
-    value_type w3 = difference_of_products(A(0, 0), A(0, 1), w1, w0);
-    value_type det = std::fma(A(0, 2), w2, w3);
-    assert(det != 0.);
-    value_type idet = 1 / det;
-
-    B(0, 0) = w0 * idet;
-    B(1, 0) = -w1 * idet;
-    B(2, 0) = w2 * idet;
-    B(0, 1) = difference_of_products(A(0, 2), A(0, 1), A(2, 2), A(2, 1)) * idet;
-    B(0, 2) = difference_of_products(A(0, 1), A(0, 2), A(1, 1), A(1, 2)) * idet;
-    B(1, 1) = difference_of_products(A(0, 0), A(0, 2), A(2, 0), A(2, 2)) * idet;
-    B(1, 2) = difference_of_products(A(1, 0), A(0, 0), A(1, 2), A(0, 2)) * idet;
-    B(2, 1) = difference_of_products(A(2, 0), A(0, 0), A(2, 1), A(0, 1)) * idet;
-    B(2, 2) = difference_of_products(A(0, 0), A(1, 0), A(0, 1), A(1, 1)) * idet;
-    break;
-  }
-  default:
-    throw std::runtime_error("math::inv is not implemented for " + std::to_string(A.shape(0)) + "x"
-                             + std::to_string(A.shape(1)) + " matrices.");
-  }
-}
-} // namespace
 namespace dolfinx_cuas::math
 {
+
+/// Compute C += B^T * A^T
+/// @param[in] A Input matrix
+/// @param[in] B Input matrix
+/// @param[in, out] C Filled to be C += B^T * A^T
+template <typename U, typename V, typename P>
+void dotT(const U& A, const V& B, P& C)
+{
+  assert(A.shape(1) == B.shape(0));
+  assert(C.shape(0) == B.shape(1));
+  assert(C.shape(1) == A.shape(0));
+  for (std::size_t k = 0; k < B.shape(1); k++)
+    for (std::size_t i = 0; i < A.shape(0); i++)
+      for (std::size_t l = 0; l < B.shape(0); l++)
+        C(k, i) += B(l, k) * A(i, l);
+}
 
 template <typename U, typename V>
 void compute_inv(const U& A, V& B)
@@ -113,14 +36,11 @@ void compute_inv(const U& A, V& B)
   const int ncols = A.shape(1);
   if (nrows == ncols)
   {
-    inv(A, B);
+    dolfinx::math::inv(A, B);
   }
   else
   {
-    auto ATA = xt::linalg::dot(xt::transpose(A), A);
-    xt::xtensor<value_type, 2> ATAinv = xt::zeros<value_type>({ncols, ncols});
-    inv(ATA, ATAinv);
-    B = xt::linalg::dot(ATAinv, xt::transpose(A));
+    dolfinx::math::pinv(A, B);
   }
 }
 
@@ -130,11 +50,14 @@ template <typename Matrix>
 double compute_determinant(Matrix& A)
 {
   if (A.shape(0) == A.shape(1))
-    return det(A);
+    return dolfinx::math::det(A);
   else
   {
-    auto ATA = xt::linalg::dot(xt::transpose(A), A);
-    return std::sqrt(det(ATA));
+    using T = typename Matrix::value_type;
+    xt::xtensor<T, 2> B = xt::transpose(A);
+    xt::xtensor<T, 2> BA = xt::zeros<T>({B.shape(0), A.shape(1)});
+    dolfinx::math::dot(B, A, BA);
+    return std::sqrt(dolfinx::math::det(BA));
   }
 }
 
@@ -147,7 +70,8 @@ void compute_jacobian(const U& dphi, const V& coords, P& J)
   assert(J.shape(0) == coords.shape(1));
   assert(J.shape(1) == dphi.shape(0));
   assert(dphi.shape(1) == coords.shape(0));
-  J = xt::transpose(xt::linalg::dot(dphi, coords));
+
+  dotT(dphi, coords, J);
 }
 
 } // namespace dolfinx_cuas::math

--- a/cpp/math.hpp
+++ b/cpp/math.hpp
@@ -12,22 +12,6 @@
 namespace dolfinx_cuas::math
 {
 
-/// Compute C += B^T * A^T
-/// @param[in] A Input matrix
-/// @param[in] B Input matrix
-/// @param[in, out] C Filled to be C += B^T * A^T
-template <typename U, typename V, typename P>
-void dotT(const U& A, const V& B, P& C)
-{
-  assert(A.shape(1) == B.shape(0));
-  assert(C.shape(0) == B.shape(1));
-  assert(C.shape(1) == A.shape(0));
-  for (std::size_t k = 0; k < B.shape(1); k++)
-    for (std::size_t i = 0; i < A.shape(0); i++)
-      for (std::size_t l = 0; l < B.shape(0); l++)
-        C(k, i) += B(l, k) * A(i, l);
-}
-
 template <typename U, typename V>
 void compute_inv(const U& A, V& B)
 {
@@ -71,7 +55,7 @@ void compute_jacobian(const U& dphi, const V& coords, P& J)
   assert(J.shape(1) == dphi.shape(0));
   assert(dphi.shape(1) == coords.shape(0));
 
-  dotT(dphi, coords, J);
+  dolfinx::math::dot(coords, dphi, J, true);
 }
 
 } // namespace dolfinx_cuas::math

--- a/cpp/surface_kernels.hpp
+++ b/cpp/surface_kernels.hpp
@@ -12,6 +12,7 @@
 #include "utils.hpp"
 #include <dolfinx/fem/FiniteElement.h>
 #include <dolfinx/fem/FunctionSpace.h>
+#include <xtensor/xadapt.hpp>
 
 namespace dolfinx_cuas
 {
@@ -28,58 +29,49 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
   const int tdim = mesh->topology().dim(); // topological dimension
   const int fdim = tdim - 1;               // topological dimension of facet
 
-  // Create coordinate elements (for facet and cell)
-  const basix::FiniteElement surface_element = mesh_to_basix_element(mesh, fdim);
+  // Create coordinate elements for cell
   const basix::FiniteElement basix_element = mesh_to_basix_element(mesh, tdim);
   const int num_coordinate_dofs = basix_element.dim();
 
   // Create quadrature points on reference facet
-  xt::xarray<double>& qp_ref_facet = quadrature_rule.points_ref();
-  xt::xarray<double>& q_weights = quadrature_rule.weights_ref();
+  std::vector<xt::xarray<double>>& q_points = quadrature_rule.points_ref();
+  std::vector<std::vector<double>>& q_weights = quadrature_rule.weights_ref();
 
-  // Tabulate coordinate element of reference facet (used to compute Jacobian on
-  // facet) and push forward quadrature points
-  auto f_tab = surface_element.tabulate(0, qp_ref_facet);
-  xt::xtensor<double, 2> phi_f = xt::view(f_tab, 0, xt::all(), xt::all(), 0);
-
-  // Structures required for pushing forward quadrature points
-  auto facets
-      = basix::cell::topology(basix_element.cell_type())[tdim - 1]; // Topology of basix facets
-  const xt::xtensor<double, 2> x
-      = basix::cell::geometry(basix_element.cell_type()); // Geometry of basix cell
-  const std::uint32_t num_facets = facets.size();
-  const std::uint32_t num_quadrature_pts = qp_ref_facet.shape(0);
+  const std::uint32_t num_facets = q_weights.size();
 
   // Structures needed for basis function tabulation
-  // phi and grad(phi) at quadrature points
+  // phi and grad(phi) and coordinate element derivative at quadrature points
   std::shared_ptr<const dolfinx::fem::FiniteElement> element = V->element();
   int bs = element->block_size();
   std::uint32_t num_local_dofs = element->space_dimension() / bs;
-  xt::xtensor<double, 3> phi({num_facets, num_quadrature_pts, num_local_dofs});
-  xt::xtensor<double, 4> dphi({num_facets, tdim, num_quadrature_pts, num_local_dofs});
-  xt::xtensor<double, 4> cell_tab({tdim + 1, num_quadrature_pts, num_local_dofs, bs});
+  std::vector<xt::xtensor<double, 2>> phi;
+  phi.reserve(num_facets);
+  std::vector<xt::xtensor<double, 3>> dphi;
+  phi.reserve(num_facets);
+  std::vector<xt ::xtensor<double, 3>> dphi_c;
+  dphi_c.reserve(num_facets);
 
-  // Structure needed for jacobian of cell basis function
-  xt::xtensor<double, 4> dphi_c({num_facets, tdim, num_quadrature_pts, basix_element.dim()});
-
+  // Tabulate basis functions (for test/trial function) and coordinate element at
+  // quadrature points
   for (int i = 0; i < num_facets; ++i)
   {
-    // Push quadrature points forward
-    auto facet = facets[i];
-    auto coords = xt::view(x, xt::keep(facet), xt::all());
-    auto q_facet = xt::linalg::dot(phi_f, coords);
+    xt::xarray<double>& q_facet = q_points[i];
+    const int num_quadrature_points = q_facet.shape(0);
+    xt::xtensor<double, 4> cell_tab({tdim + 1, num_quadrature_points, num_local_dofs, bs});
 
     // Tabulate at quadrature points on facet
-    auto phi_i = xt::view(phi, i, xt::all(), xt::all());
-    auto dphi_i = xt::view(dphi, i, xt::all(), xt::all(), xt::all());
     element->tabulate(cell_tab, q_facet, 1);
-    phi_i = xt::view(cell_tab, 0, xt::all(), xt::all(), 0);
-    dphi_i = xt::view(cell_tab, xt::range(1, tdim + 1), xt::all(), xt::all(), 0);
+    xt::xtensor<double, 2> phi_i = xt::view(cell_tab, 0, xt::all(), xt::all(), 0);
+    phi.push_back(phi_i);
+    xt::xtensor<double, 3> dphi_i
+        = xt::view(cell_tab, xt::range(1, tdim + 1), xt::all(), xt::all(), 0);
+    dphi.push_back(dphi_i);
 
     // Tabulate coordinate element of reference cell
     auto c_tab = basix_element.tabulate(1, q_facet);
-    auto dphi_ci = xt::view(dphi_c, i, xt::all(), xt::all(), xt::all());
-    dphi_ci = xt::view(c_tab, xt::range(1, tdim + 1), xt::all(), xt::all(), 0);
+    xt::xtensor<double, 3> dphi_ci
+        = xt::view(c_tab, xt::range(1, tdim + 1), xt::all(), xt::all(), 0);
+    dphi_c.push_back(dphi_ci);
   }
 
   // As reference facet and reference cell are affine, we do not need to compute this per
@@ -90,25 +82,20 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
   auto facet_normals = basix::cell::facet_outward_normals(basix_element.cell_type());
 
   // Define kernels
-  kernel_fn mass
-      = [dphi_c, phi, gdim, tdim, fdim, bs, q_weights, num_coordinate_dofs,
-         ref_jacobians](double* A, const double* c, const double* w, const double* coordinate_dofs,
-                        const int* entity_local_index, const std::uint8_t* quadrature_permutation)
+  kernel_fn mass = [=](double* A, const double* c, const double* w, const double* coordinate_dofs,
+                       const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
     std::size_t facet_index = size_t(*entity_local_index);
 
     // Reshape coordinate dofs to two dimensional array
     // NOTE: DOLFINx has 3D input coordinate dofs
     std::array<std::size_t, 2> shape = {num_coordinate_dofs, 3};
-
-    // FIXME: These array should be views (when compute_jacobian doesn't use xtensor)
-    xt::xtensor<double, 2> coord
+    const xt::xtensor<double, 2> coord
         = xt::adapt(coordinate_dofs, num_coordinate_dofs * 3, xt::no_ownership(), shape);
 
-    // Extract the first derivative of the coordinate element (cell) of degrees of freedom on
-    // the facet
-    xt::xtensor<double, 2> dphi0_c
-        = xt::view(dphi_c, facet_index, xt::all(), 0,
+    const xt::xtensor<double, 3>& dphi_fc = dphi_c[facet_index];
+    const xt::xtensor<double, 2>& dphi0_c
+        = xt::view(dphi_fc, xt::all(), 0,
                    xt::all()); // FIXME: Assumed constant, i.e. only works for simplices
 
     // Compute Jacobian and determinant at each quadrature point
@@ -116,65 +103,66 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
     dolfinx_cuas::math::compute_jacobian(dphi0_c, coord, J);
 
     // Compute det(J_C J_f) as it is the mapping to the reference facet
-    xt::xtensor<double, 2> J_f = xt::view(ref_jacobians, facet_index, xt::all(), xt::all());
-    xt::xtensor<double, 2> J_tot = xt::linalg::dot(J, J_f);
+    auto J_f = xt::view(ref_jacobians, facet_index, xt::all(), xt::all());
+    auto J_tot = xt::linalg::dot(J, J_f);
     double detJ = std::fabs(dolfinx_cuas::math::compute_determinant(J_tot));
 
     // Get number of dofs per cell
-    // FIXME: Should be templated
-    std::int32_t ndofs_cell = phi.shape(2);
-
+    const std::vector<double>& weights = q_weights[facet_index];
+    const xt::xtensor<double, 2>& phi_f = phi[facet_index];
     // Loop over quadrature points
-    for (std::size_t q = 0; q < phi.shape(1); q++)
+    for (std::size_t q = 0; q < weights.size(); q++)
     {
       // Scale at each quadrature point
-      const double w0 = q_weights[q] * detJ;
+      const double w0 = weights[q] * detJ;
 
-      for (int i = 0; i < ndofs_cell; i++)
+      for (int i = 0; i < num_local_dofs; i++)
       {
         // Compute a weighted phi_i(p_q),  i.e. phi_i(p_q) det(J) w_q
-        double w1 = w0 * phi(facet_index, q, i);
-        for (int j = 0; j < ndofs_cell; j++)
+        double w1 = w0 * phi_f(q, i);
+        for (int j = 0; j < num_local_dofs; j++)
         {
           // Compute phi_j(p_q) phi_i(p_q) det(J) w_q (block invariant)
-          const double integrand = w1 * phi(facet_index, q, j);
+          const double integrand = w1 * phi_f(q, j);
 
           // Insert over block size in matrix
           for (int k = 0; k < bs; k++)
-            A[(k + i * bs) * (ndofs_cell * bs) + k + j * bs] += integrand;
+            A[(k + i * bs) * (num_local_dofs * bs) + k + j * bs] += integrand;
         }
       }
     }
   };
 
   kernel_fn mass_nonaffine
-      = [phi, dphi_c, gdim, tdim, fdim, bs, q_weights, num_coordinate_dofs,
-         ref_jacobians](double* A, const double* c, const double* w, const double* coordinate_dofs,
-                        const int* entity_local_index, const std::uint8_t* quadrature_permutation)
+      = [=](double* A, const double* c, const double* w, const double* coordinate_dofs,
+            const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
     std::size_t facet_index = size_t(*entity_local_index);
 
     // Reshape coordinate dofs to two dimensional array
     // NOTE: DOLFINx has 3D input coordinate dofs
     std::array<std::size_t, 2> shape = {num_coordinate_dofs, 3};
-    xt::xtensor<double, 2> coord
+    const xt::xtensor<double, 2>& coord
         = xt::adapt(coordinate_dofs, num_coordinate_dofs * 3, xt::no_ownership(), shape);
 
     // Compute Jacobian and determinant at each quadrature point
     xt::xtensor<double, 2> J = xt::zeros<double>({gdim, fdim});
-    xt::xtensor<double, 2> J_f = xt::view(ref_jacobians, facet_index, xt::all(), xt::all());
+    const xt::xtensor<double, 2>& J_f = xt::view(ref_jacobians, facet_index, xt::all(), xt::all());
 
-    // Get number of dofs per cell
-    // FIXME: Should be templated
-    std::int32_t ndofs_cell = phi.shape(2);
+    const std::vector<double>& weights = q_weights[facet_index];
+    const xt::xtensor<double, 2>& phi_f = phi[facet_index];
+    const xt::xtensor<double, 3>& dphi_fc = dphi_c[facet_index];
+    const xt::xtensor<double, 2>& dphi0_c
+        = xt::view(dphi_fc, xt::all(), 0,
+                   xt::all()); // FIXME: Assumed constant, i.e. only works for simplices
 
     // Loop over quadrature points
-    for (std::size_t q = 0; q < phi.shape(1); q++)
+    for (std::size_t q = 0; q < weights.size(); q++)
     {
 
       // Extract the first derivative of the coordinate element (cell) of degrees of freedom
       // on the facet
-      xt::xtensor<double, 2> dphi_c_q = xt::view(dphi_c, facet_index, xt::all(), q, xt::all());
+      const xt::xtensor<double, 2>& dphi_c_q = xt::view(dphi_fc, xt::all(), q, xt::all());
       dolfinx_cuas::math::compute_jacobian(dphi_c_q, coord, J);
 
       // Compute det(J_C J_f) as it is the mapping to the reference facet
@@ -182,42 +170,40 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
       double detJ = std::fabs(dolfinx_cuas::math::compute_determinant(J_tot));
 
       // Scale at each quadrature point
-      const double w0 = q_weights[q] * detJ;
+      const double w0 = weights[q] * detJ;
 
-      for (int i = 0; i < ndofs_cell; i++)
+      for (int i = 0; i < num_local_dofs; i++)
       {
         // Compute a weighted phi_i(p_q),  i.e. phi_i(p_q) det(J) w_q
-        double w1 = w0 * phi(facet_index, q, i);
-        for (int j = 0; j < ndofs_cell; j++)
+        double w1 = w0 * phi_f(q, i);
+        for (int j = 0; j < num_local_dofs; j++)
         {
           // Compute phi_j(p_q) phi_i(p_q) det(J) w_q (block invariant)
-          const double integrand = w1 * phi(facet_index, q, j);
+          const double integrand = w1 * phi_f(q, j);
 
           // Insert over block size in matrix
           for (int k = 0; k < bs; k++)
-            A[(k + i * bs) * (ndofs_cell * bs) + k + j * bs] += integrand;
+            A[(k + i * bs) * (num_local_dofs * bs) + k + j * bs] += integrand;
         }
       }
     }
   };
   // FIXME: Template over gdim and tdim?
   kernel_fn stiffness
-      = [dphi, gdim, tdim, fdim, bs, dphi_c, q_weights, num_coordinate_dofs,
-         ref_jacobians](double* A, const double* c, const double* w, const double* coordinate_dofs,
-                        const int* entity_local_index, const std::uint8_t* quadrature_permutation)
+      = [=](double* A, const double* c, const double* w, const double* coordinate_dofs,
+            const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
     std::size_t facet_index = size_t(*entity_local_index);
     // Reshape coordinate dofs to two dimensional array
     // NOTE: DOLFINx has 3D input coordinate dofs
     std::array<std::size_t, 2> shape = {num_coordinate_dofs, 3};
-    xt::xtensor<double, 2> coord
-        = xt::adapt(coordinate_dofs, num_coordinate_dofs * 3, xt::no_ownership(), shape);
+    auto coord = xt::adapt(coordinate_dofs, num_coordinate_dofs * 3, xt::no_ownership(), shape);
 
     // Extract the first derivative of the coordinate element (cell) of degrees of freedom on
     // the facet
-    xt::xtensor<double, 2> dphi0_c
-        = xt::view(dphi_c, facet_index, xt::all(), 0,
-                   xt::all()); // FIXME: Assumed constant, i.e. only works for simplices
+    const xt::xtensor<double, 3>& dphi_fc = dphi_c[facet_index];
+    auto dphi0_c = xt::view(dphi_fc, xt::all(), 0,
+                            xt::all()); // FIXME: Assumed constant, i.e. only works for simplices
 
     // Compute Jacobian and inverse of cell mapping at each quadrature point
     xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
@@ -230,28 +216,28 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
     xt::xtensor<double, 2> J_tot = xt::linalg::dot(J, J_f);
     double detJ = std::fabs(dolfinx_cuas::math::compute_determinant(J_tot));
 
-    // Get number of dofs per cell.
-    // FIXME: This should be templated
-    std::int32_t ndofs_cell = dphi.shape(3);
-
     // Temporary variable for grad(phi) on physical cell
-    xt::xtensor<double, 2> dphi_phys({gdim, ndofs_cell});
+    xt::xtensor<double, 2> dphi_phys({gdim, num_local_dofs});
+
+    const std::vector<double>& weights = q_weights[facet_index];
+    const xt::xtensor<double, 2>& phi_f = phi[facet_index];
+    const xt::xtensor<double, 3>& dphi_f = dphi[facet_index];
 
     // Loop over quadrature points.
-    for (std::size_t q = 0; q < dphi.shape(2); q++)
+    for (std::size_t q = 0; q < weights.size(); q++)
     {
       // Scale for integral. NOTE: for non-simplices detJ is detJ[q]
-      const double w0 = q_weights[q] * detJ;
+      const double w0 = weights[q] * detJ;
 
       // Precompute J^-T * dphi
       std::fill(dphi_phys.begin(), dphi_phys.end(), 0);
-      for (int i = 0; i < ndofs_cell; i++)
+      for (int i = 0; i < num_local_dofs; i++)
         for (int k = 0; k < tdim; k++)
           for (int j = 0; j < gdim; j++)
-            dphi_phys(j, i) += K(k, j) * dphi(*entity_local_index, k, q, i);
+            dphi_phys(j, i) += K(k, j) * dphi_f(k, q, i);
 
-      for (int i = 0; i < ndofs_cell; i++)
-        for (int j = 0; j < ndofs_cell; j++)
+      for (int i = 0; i < num_local_dofs; i++)
+        for (int j = 0; j < num_local_dofs; j++)
         {
           // Compute dphi_i/dx_k dphi_j/dx_k (block invariant)
           double block_invariant_contr = 0;
@@ -260,29 +246,28 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
           block_invariant_contr *= w0;
           // Insert into local matrix (repeated over block size)
           for (int k = 0; k < bs; k++)
-            A[(k + i * bs) * (ndofs_cell * bs) + k + j * bs] += block_invariant_contr;
+            A[(k + i * bs) * (num_local_dofs * bs) + k + j * bs] += block_invariant_contr;
         }
     }
   };
 
   kernel_fn sym_grad
-      = [dphi, gdim, tdim, fdim, bs, dphi_c, q_weights, num_coordinate_dofs,
-         ref_jacobians](double* A, const double* c, const double* w, const double* coordinate_dofs,
-                        const int* entity_local_index, const std::uint8_t* quadrature_permutation)
+      = [=](double* A, const double* c, const double* w, const double* coordinate_dofs,
+            const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
     assert(bs == tdim);
     std::size_t facet_index = size_t(*entity_local_index);
     // Reshape coordinate dofs to two dimensional array
     // NOTE: DOLFINx assumes 3D coordinate dofs input
     std::array<std::size_t, 2> shape = {num_coordinate_dofs, 3};
-    xt::xtensor<double, 2> coord
-        = xt::adapt(coordinate_dofs, num_coordinate_dofs * 3, xt::no_ownership(), shape);
+    auto coord = xt::adapt(coordinate_dofs, num_coordinate_dofs * 3, xt::no_ownership(), shape);
 
     // Extract the first derivative of the coordinate element(cell) of degrees of freedom on
     // the facet
-    xt::xtensor<double, 2> dphi0_c
-        = xt::view(dphi_c, facet_index, xt::all(), 0,
-                   xt::all()); // FIXME: Assumed constant, i.e. only works for simplices
+    const xt::xtensor<double, 3>& dphi_cf = dphi_c[facet_index];
+    auto dphi0_c
+        = xt::view(dphi_cf, xt::all(), 0,
+                   xt::all()); // dphi_cf FIXME: Assumed constant, i.e. only works for simplices
 
     // Compute Jacobian and inverse of cell mapping at each quadrature point
     xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
@@ -295,31 +280,32 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
     xt::xtensor<double, 2> J_tot = xt::linalg::dot(J, J_f);
     double detJ = std::fabs(dolfinx_cuas::math::compute_determinant(J_tot));
 
-    // Get number of dofs per cell
-    // FIXME: Should be templated
-    std::int32_t ndofs_cell = dphi.shape(3);
-
     // Temporary variable for grad(phi) on physical cell
-    xt::xtensor<double, 2> dphi_phys({gdim, ndofs_cell});
+    xt::xtensor<double, 2> dphi_phys({gdim, num_local_dofs});
+
+    // Get tables for facet
+    const std::vector<double>& weights = q_weights[facet_index];
+    const xt::xtensor<double, 2>& phi_f = phi[facet_index];
+    const xt::xtensor<double, 3>& dphi_f = dphi[facet_index];
 
     // Loop over quadrature points
-    for (std::size_t q = 0; q < dphi.shape(2); q++)
+    for (std::size_t q = 0; q < weights.size(); q++)
     {
       // Create for integral. NOTE: for non-simplices detJ is detJ[q]
-      const double w0 = q_weights[q] * detJ;
+      const double w0 = weights[q] * detJ;
 
       // Precompute J^-T * dphi
       std::fill(dphi_phys.begin(), dphi_phys.end(), 0);
-      for (int i = 0; i < ndofs_cell; i++)
+      for (int i = 0; i < num_local_dofs; i++)
         for (int j = 0; j < gdim; j++)
           for (int k = 0; k < tdim; k++)
-            dphi_phys(j, i) += K(k, j) * dphi(*entity_local_index, k, q, i);
+            dphi_phys(j, i) += K(k, j) * dphi_f(k, q, i);
 
       // This corresponds to the term sym(grad(u)):sym(grad(v)) (see
       // https://www.overleaf.com/read/wnvkgjfnhkrx for details)
-      for (int i = 0; i < ndofs_cell; i++)
+      for (int i = 0; i < num_local_dofs; i++)
       {
-        for (int j = 0; j < ndofs_cell; j++)
+        for (int j = 0; j < num_local_dofs; j++)
         {
           // Compute sum_t dphi^j/dx_t dphi^i/dx_t
           // Component is invarient of block size
@@ -330,7 +316,7 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
 
           for (int k = 0; k < bs; ++k)
           {
-            const std::size_t row = (k + i * bs) * (ndofs_cell * bs);
+            const std::size_t row = (k + i * bs) * (num_local_dofs * bs);
             A[row + j * bs + k] += block_invariant_cont;
 
             // Add dphi^j/dx_k dphi^i/dx_l
@@ -341,10 +327,8 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
       }
     }
   };
-  kernel_fn normal
-      = [phi, dphi, gdim, tdim, fdim, bs, dphi_c, q_weights, num_coordinate_dofs, ref_jacobians,
-         facet_normals](double* A, const double* c, const double* w, const double* coordinate_dofs,
-                        const int* entity_local_index, const std::uint8_t* quadrature_permutation)
+  kernel_fn normal = [=](double* A, const double* c, const double* w, const double* coordinate_dofs,
+                         const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
     assert(bs == tdim);
     std::size_t facet_index = size_t(*entity_local_index);
@@ -356,9 +340,9 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
 
     // Extract the first derivative of the coordinate element(cell) of degrees of freedom on
     // the facet
-    xt::xtensor<double, 2> dphi0_c
-        = xt::view(dphi_c, facet_index, xt::all(), 0,
-                   xt::all()); // FIXME: Assumed constant, i.e. only works for simplices
+    const xt::xtensor<double, 3> dphi_cf = dphi_c[facet_index];
+    auto dphi0_c = xt::view(dphi_cf, xt::all(), 0,
+                            xt::all()); // FIXME: Assumed constant, i.e. only works for simplices
 
     // Compute Jacobian and inverse of cell mapping at each quadrature point
     xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
@@ -381,45 +365,45 @@ kernel_fn generate_surface_kernel(std::shared_ptr<const dolfinx::fem::FunctionSp
     xt::xtensor<double, 2> J_tot = xt::linalg::dot(J, J_f);
     double detJ = std::fabs(dolfinx_cuas::math::compute_determinant(J_tot));
 
-    // Get number of dofs per cell
-    // FIXME: Should be templated
-    std::int32_t ndofs_cell = dphi.shape(3);
+    // Get tables for facet
+    const std::vector<double>& weights = q_weights[facet_index];
+    const xt::xtensor<double, 2>& phi_f = phi[facet_index];
+    const xt::xtensor<double, 3>& dphi_f = dphi[facet_index];
 
     // Temporary variable for grad(phi) on physical cell
-    xt::xtensor<double, 2> dphi_phys({gdim, ndofs_cell});
+    xt::xtensor<double, 2> dphi_phys({gdim, num_local_dofs});
 
     // Loop over quadrature points
-    for (std::size_t q = 0; q < dphi.shape(2); q++)
+    for (std::size_t q = 0; q < weights.size(); q++)
     {
       // Create for integral. NOTE: for non-simplices detJ is detJ[q]
-      const double w0 = q_weights[q] * detJ;
+      const double w0 = weights[q] * detJ;
 
       // Precompute J^-T * dphi
       std::fill(dphi_phys.begin(), dphi_phys.end(), 0);
-      for (int i = 0; i < ndofs_cell; i++)
+      for (int i = 0; i < num_local_dofs; i++)
         for (int j = 0; j < gdim; j++)
           for (int k = 0; k < tdim; k++)
-            dphi_phys(j, i) += K(k, j) * dphi(facet_index, k, q, i);
-
-      for (int j = 0; j < ndofs_cell; j++)
+            dphi_phys(j, i) += K(k, j) * dphi_f(k, q, i);
+      for (int j = 0; j < num_local_dofs; j++)
       {
-        for (int i = 0; i < ndofs_cell; i++)
+        for (int i = 0; i < num_local_dofs; i++)
         {
           // Compute sum_s dphi_phys^i/dx_s n_s \phi^j
           // Component is invarient of block size
           double block_invariant_cont = 0;
           for (int s = 0; s < gdim; s++)
-            block_invariant_cont += dphi_phys(s, i) * n_phys(s) * phi(facet_index, q, j);
+            block_invariant_cont += dphi_phys(s, i) * n_phys(s) * phi_f(q, j);
           block_invariant_cont *= w0;
 
           for (int l = 0; l < bs; ++l)
           {
-            const std::size_t row = (l + j * bs) * (ndofs_cell * bs);
+            const std::size_t row = (l + j * bs) * (num_local_dofs * bs);
             A[row + i * bs + l] += block_invariant_cont;
 
             // Add dphi^j/dx_k dphi^i/dx_l
             for (int b = 0; b < bs; ++b)
-              A[row + i * bs + b] += w0 * dphi_phys(l, i) * n_phys(b) * phi(facet_index, q, j);
+              A[row + i * bs + b] += w0 * dphi_phys(l, i) * n_phys(b) * phi_f(q, j);
           }
         }
       }

--- a/cpp/utils.hpp
+++ b/cpp/utils.hpp
@@ -59,50 +59,6 @@ basix::FiniteElement mesh_to_basix_element(std::shared_ptr<const dolfinx::mesh::
     throw std::runtime_error("Does not support elements of edges and vertices");
 }
 
-// Compute quadrature points and weights on all facets of the reference cell
-/// by pushing them forward from the reference facet.
-/// @param[in] mesh The mesh
-/// @param[in] quadrature_degree Degree of quadrature rule
-std::pair<xt::xtensor<double, 3>, std::vector<double>>
-create_reference_facet_qp(std::shared_ptr<const dolfinx::mesh::Mesh> mesh, int quadrature_degree)
-{
-  // Mesh info
-  const int tdim = mesh->topology().dim(); // topological dimension
-  const int fdim = tdim - 1;               // topological dimesnion of facet
-
-  const basix::cell::type basix_cell
-      = dolfinx::mesh::cell_type_to_basix_type(mesh->topology().cell_type());
-
-  // Create basix facet coordinate element
-  const basix::FiniteElement surface_element = mesh_to_basix_element(mesh, fdim);
-
-  // Create facet quadrature points
-  const basix::cell::type basix_facet = surface_element.cell_type();
-  std::pair<xt::xarray<double>, std::vector<double>> quadrature
-      = basix::quadrature::make_quadrature("default", basix_facet, quadrature_degree);
-
-  // Tabulate facet coordinate functions
-  auto c_tab = surface_element.tabulate(0, quadrature.first);
-  xt::xtensor<double, 2> phi_s = xt::view(c_tab, 0, xt::all(), xt::all(), 0);
-
-  // Create reference topology and geometry
-  auto facet_topology = basix::cell::topology(basix_cell)[fdim];
-  const xt::xtensor<double, 2> ref_geom = basix::cell::geometry(basix_cell);
-
-  // Push forward quadrature points on reference facet to reference cell
-  const std::uint32_t num_facets = facet_topology.size();
-  const std::uint32_t num_quadrature_pts = quadrature.first.shape(0);
-  xt::xtensor<double, 3> qp_ref_facet({num_facets, num_quadrature_pts, ref_geom.shape(1)});
-  for (int i = 0; i < num_facets; ++i)
-  {
-    auto facet = facet_topology[i];
-    auto coords = xt::view(ref_geom, xt::keep(facet), xt::all());
-    auto q_facet = xt::view(qp_ref_facet, i, xt::all(), xt::all());
-    q_facet = xt::linalg::dot(phi_s, coords);
-  }
-  return {qp_ref_facet, quadrature.second};
-}
-
 /// Returns true if two PETSc matrices are element-wise equal within a tolerance.
 /// @param[in] A PETSc Matrix to compare
 /// @param[in] B PETSc Matrix to compare

--- a/cpp/utils.hpp
+++ b/cpp/utils.hpp
@@ -17,7 +17,6 @@
 #include <dolfinx/fem/petsc.h>
 #include <dolfinx/fem/utils.h>
 #include <dolfinx/mesh/Mesh.h>
-#include <xtensor-blas/xlinalg.hpp>
 
 namespace dolfinx_cuas
 {

--- a/python/setup.py
+++ b/python/setup.py
@@ -7,7 +7,7 @@ from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
 
-VERSION = "0.1.0"
+VERSION = "0.3.1"
 
 REQUIREMENTS = []
 

--- a/python/tests/test_bcs.py
+++ b/python/tests/test_bcs.py
@@ -50,7 +50,8 @@ def test_dirichlet_bc(P):
     num_local_cells = mesh.topology.index_map(mesh.topology.dim).size_local
     active_cells = np.arange(num_local_cells, dtype=np.int32)
     B = dolfinx.fem.create_matrix(a)
-    q_rule = dolfinx_cuas.cpp.QuadratureRule(mesh.topology.cell_type, P + P, "default")
+    q_rule = dolfinx_cuas.cpp.QuadratureRule(mesh.topology.cell_type, P + P, mesh.topology.dim, "default")
+
     kernel = dolfinx_cuas.cpp.generate_kernel(kernel_type, P, bs, q_rule)
     B.zeroEntries()
     consts = np.zeros(0)

--- a/python/tests/test_coeff_kernels.py
+++ b/python/tests/test_coeff_kernels.py
@@ -61,7 +61,7 @@ def test_volume_kernels(kernel_type, P, Q):
     active_cells = np.arange(num_local_cells, dtype=np.int32)
     B = dolfinx.fem.create_matrix(a)
     quadrature_degree = 2 * P + Q
-    q_rule = dolfinx_cuas.cpp.QuadratureRule(mesh.topology.cell_type, quadrature_degree, "default")
+    q_rule = dolfinx_cuas.cpp.QuadratureRule(mesh.topology.cell_type, quadrature_degree, mesh.topology.dim, "default")
     kernel = dolfinx_cuas.cpp.generate_coeff_kernel(kernel_type, [mu._cpp_object, lam._cpp_object], P, q_rule)
     B.zeroEntries()
     consts = np.zeros(0)

--- a/python/tests/test_cpp_kernels.py
+++ b/python/tests/test_cpp_kernels.py
@@ -64,14 +64,14 @@ def test_manifold(kernel_type):
     consts = np.zeros(0)
     coeffs = np.zeros((num_local_cells, 0), dtype=PETSc.ScalarType)
     B = dolfinx.fem.create_matrix(a)
-    # FIXME: Does not work for prism meshes
-    facet_type = dolfinx.cpp.mesh.cell_entity_type(mesh.topology.cell_type, mesh.topology.dim - 1, 0)
-    q_rule = dolfinx_cuas.cpp.QuadratureRule(facet_type, quadrature_degree, "default")
+    fdim = mesh.topology.dim - 1
+    q_rule = dolfinx_cuas.cpp.QuadratureRule(mesh.topology.cell_type, quadrature_degree, fdim, "default")
+
     kernel = dolfinx_cuas.cpp.generate_surface_kernel(V._cpp_object, kernel_type, q_rule)
     B.zeroEntries()
     dolfinx_cuas.assemble_matrix(B, V, ft.indices, kernel, coeffs, consts, it.exterior_facet)
     B.assemble()
-
+    compare_matrices(A, B)
     # Compare matrices, first norm, then entries
     assert np.isclose(A.norm(), B.norm())
 
@@ -121,10 +121,8 @@ def test_surface_kernels(dim, kernel_type):
     coeffs = np.zeros((num_local_cells, 0), dtype=PETSc.ScalarType)
 
     B = dolfinx.fem.create_matrix(a)
-
-    # FIXME: Does not work for prism meshes
-    facet_type = dolfinx.cpp.mesh.cell_entity_type(mesh.topology.cell_type, mesh.topology.dim - 1, 0)
-    q_rule = dolfinx_cuas.cpp.QuadratureRule(facet_type, quadrature_degree, "default")
+    q_rule = dolfinx_cuas.cpp.QuadratureRule(
+        mesh.topology.cell_type, quadrature_degree, mesh.topology.dim - 1, "default")
     kernel = dolfinx_cuas.cpp.generate_surface_kernel(V._cpp_object, kernel_type, q_rule)
 
     B.zeroEntries()
@@ -180,8 +178,8 @@ def test_normal_kernels(dim, kernel_type):
     B = dolfinx.fem.create_matrix(a)
 
     # FIXME: Does not work for prism meshes
-    facet_type = dolfinx.cpp.mesh.cell_entity_type(mesh.topology.cell_type, mesh.topology.dim - 1, 0)
-    q_rule = dolfinx_cuas.cpp.QuadratureRule(facet_type, quadrature_degree, "default")
+    fdim = mesh.topology.dim - 1
+    q_rule = dolfinx_cuas.cpp.QuadratureRule(mesh.topology.cell_type, quadrature_degree, fdim, "default")
     kernel = dolfinx_cuas.cpp.generate_surface_kernel(V._cpp_object, kernel_type, q_rule)
     B.zeroEntries()
     dolfinx_cuas.assemble_matrix(B, V, ft.indices, kernel, coeffs, consts, it.exterior_facet)
@@ -228,7 +226,7 @@ def test_volume_kernels(kernel_type, P):
     num_local_cells = mesh.topology.index_map(mesh.topology.dim).size_local
     active_cells = np.arange(num_local_cells, dtype=np.int32)
     B = dolfinx.fem.create_matrix(a)
-    q_rule = dolfinx_cuas.cpp.QuadratureRule(mesh.topology.cell_type, q_degree, "default")
+    q_rule = dolfinx_cuas.cpp.QuadratureRule(mesh.topology.cell_type, q_degree, mesh.topology.dim, "default")
     kernel = dolfinx_cuas.cpp.generate_kernel(kernel_type, P, bs, q_rule)
     B.zeroEntries()
     consts = np.zeros(0)
@@ -286,7 +284,7 @@ def test_vector_cell_kernel(kernel_type, P):
     consts = np.zeros(0)
     coeffs = np.zeros((num_local_cells, 0), dtype=PETSc.ScalarType)
     B = dolfinx.fem.create_matrix(a)
-    q_rule = dolfinx_cuas.cpp.QuadratureRule(mesh.topology.cell_type, q_degree, "default")
+    q_rule = dolfinx_cuas.cpp.QuadratureRule(mesh.topology.cell_type, q_degree, mesh.topology.dim, "default")
     kernel = dolfinx_cuas.cpp.generate_kernel(kernel_type, P, bs, q_rule)
     B.zeroEntries()
     dolfinx_cuas.assemble_matrix(B, V, active_cells, kernel, coeffs, consts, it.cell)
@@ -356,8 +354,8 @@ def test_surface_non_affine(P, vector, dim):
     coeffs = np.zeros((num_local_cells, 0), dtype=PETSc.ScalarType)
 
     # FIXME: Does not work for prism meshes
-    facet_type = dolfinx.cpp.mesh.cell_entity_type(mesh.topology.cell_type, mesh.topology.dim - 1, 0)
-    q_rule = dolfinx_cuas.cpp.QuadratureRule(facet_type, quadrature_degree, "default")
+    q_rule = dolfinx_cuas.cpp.QuadratureRule(
+        mesh.topology.cell_type, quadrature_degree, mesh.topology.dim - 1, "default")
     kernel = dolfinx_cuas.cpp.generate_surface_kernel(V._cpp_object, kt.MassNonAffine, q_rule)
 
     B.zeroEntries()

--- a/python/tests/test_vector_kernels.py
+++ b/python/tests/test_vector_kernels.py
@@ -46,7 +46,7 @@ def test_vector_kernels(dim, kernel_type, P):
     active_cells = np.arange(num_local_cells, dtype=np.int32)
     b2 = dolfinx.fem.create_vector(L)
 
-    q_rule = dolfinx_cuas.cpp.QuadratureRule(mesh.topology.cell_type, P + 1, "default")
+    q_rule = dolfinx_cuas.cpp.QuadratureRule(mesh.topology.cell_type, P + 1, mesh.topology.dim, "default")
     kernel = dolfinx_cuas.cpp.generate_vector_kernel(V._cpp_object, kernel_type, q_rule)
     b2.zeroEntries()
     consts = np.zeros(0)
@@ -93,9 +93,7 @@ def test_vector_surface_kernel(dim, kernel_type, P):
     coeffs = np.zeros((num_local_cells, 0), dtype=PETSc.ScalarType)
 
     b2 = dolfinx.fem.create_vector(L)
-    # FIXME: Does not work for prism meshes
-    facet_type = dolfinx.cpp.mesh.cell_entity_type(mesh.topology.cell_type, mesh.topology.dim - 1, 0)
-    q_rule = dolfinx_cuas.cpp.QuadratureRule(facet_type, P + 1, "default")
+    q_rule = dolfinx_cuas.cpp.QuadratureRule(mesh.topology.cell_type, P + 1, mesh.topology.dim - 1, "default")
     kernel = dolfinx_cuas.cpp.generate_surface_vector_kernel(V._cpp_object, kernel_type, q_rule)
     b2.zeroEntries()
     dolfinx_cuas.assemble_vector(b2, V, ft.indices, kernel, coeffs, consts, it.exterior_facet)


### PR DESCRIPTION
Instead of pushing forward quadrature rules in every kernel, make this a constructor of quadratureelement.

Upstream changes in asimov-contact soon to come to match this.