### PR TITLE
Add helper function for getting shape of array without returning it

### DIFF
--- a/cpp/QuadratureRule.hpp
+++ b/cpp/QuadratureRule.hpp
@@ -125,6 +125,9 @@ public:
     return dolfinx::mesh::cell_type_from_basix_type(et);
   }
 
+  /// Return the number of quadrature points per entity
+  std::size_t num_points(int i) { return _points[i].shape(0); }
+
 private:
   dolfinx::mesh::CellType _cell_type;
   int _degree;


### PR DESCRIPTION
Add helper function to get number of quadrature points in the array without returning it/exposing it to the user.
Usefull when estimating max number of quadrature points on facets of prisms