### PR TITLE
Add pkg config files to detect cuas installation

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -49,7 +49,7 @@ feature_summary(WHAT ALL)
 
 add_library(dolfinx_cuas INTERFACE)
 
-
+target_link_libraries(dolfinx_cuas INTERFACE Basix::basix)
 target_include_directories(dolfinx_cuas INTERFACE ${DOLFINX_CUAS_SOURCE_DIR})
 
 # Installation of header-only DOLFINX_CUAS Library

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -49,9 +49,29 @@ feature_summary(WHAT ALL)
 
 add_library(dolfinx_cuas INTERFACE)
 
-# Basix
-target_link_libraries(dolfinx_cuas INTERFACE Basix::basix)
+
+target_include_directories(dolfinx_cuas INTERFACE ${DOLFINX_CUAS_SOURCE_DIR})
 
 # Installation of header-only DOLFINX_CUAS Library
 include(GNUInstallDirs)
 install(FILES kernels.hpp kernelwrapper.h  math.hpp matrix_assembly.hpp vector_assembly.hpp utils.hpp surface_kernels.hpp kernels_non_const_coefficient.hpp vector_kernels.hpp QuadratureRule.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dolfinx_cuas COMPONENT Development)
+
+# Create package config for CMAKE
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(${DOLFINX_CUAS_SOURCE_DIR}/DOLFINX_CUASConfig.cmake.in
+${CMAKE_BINARY_DIR}/dolfinx_cuas/DOLFINX_CUASConfig.cmake
+INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/dolfinx_cuas)
+
+write_basic_package_version_file(${CMAKE_BINARY_DIR}/dolfinx_cuas/DOLFINX_CUASConfigVersion.cmake
+VERSION 0.3.1.0 COMPATIBILITY SameMajorVersion)
+
+# Install CMake helper files
+install(
+  FILES
+  ${CMAKE_BINARY_DIR}/dolfinx_cuas/DOLFINX_CUASConfig.cmake
+  ${CMAKE_BINARY_DIR}/dolfinx_cuas/DOLFINX_CUASConfigVersion.cmake
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/dolfinx_cuas
+  COMPONENT Development)
+
+#------------------------------------------------------------------------------

--- a/cpp/DOLFINX_CUASConfig.cmake.in
+++ b/cpp/DOLFINX_CUASConfig.cmake.in
@@ -9,6 +9,7 @@ set_and_check(DOLFINX_MPC_CXX_COMPILER "@CMAKE_CXX_COMPILER@")
 include(CMakeFindDependencyMacro)
 find_dependency(DOLFINX REQUIRED)
 find_dependency(MPI REQUIRED)
+find_dependency(Basix REQUIRED)
 
 
 check_required_components(DOLFINX_CUAS)

--- a/cpp/DOLFINX_CUASConfig.cmake.in
+++ b/cpp/DOLFINX_CUASConfig.cmake.in
@@ -1,0 +1,14 @@
+# - Build details for DOLFINX_CUAS - An extension for custom assembly with dolfinx
+#
+
+@PACKAGE_INIT@
+
+# Compilers
+set_and_check(DOLFINX_MPC_CXX_COMPILER "@CMAKE_CXX_COMPILER@")
+
+include(CMakeFindDependencyMacro)
+find_dependency(DOLFINX REQUIRED)
+find_dependency(MPI REQUIRED)
+
+
+check_required_components(DOLFINX_CUAS)

--- a/cpp/demo/volume/CMakeLists.txt
+++ b/cpp/demo/volume/CMakeLists.txt
@@ -11,6 +11,8 @@ set(CMAKE_C_FLAGS "-Ofast -march=native ${CMAKE_C_FLAGS} -Wall")
 find_package(DOLFINX REQUIRED)
 find_package(Basix REQUIRED)
 find_package(xtensor REQUIRED)
+find_package(DOLFINX_CUAS REQUIRED)
+
 
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.c

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -23,6 +23,8 @@ pybind11_add_module(cpp SHARED
 
 target_link_libraries(cpp PUBLIC pybind11::module)
 target_link_libraries(cpp PUBLIC dolfinx)
+target_link_libraries(cpp PUBLIC basix)
+
 
 # Get python include-dirs
 execute_process(


### PR DESCRIPTION
In the process of changing the contact library from header only, I realized that it was literally impossible to detect the cuas installation in the pip3 install of contact.

This PR adds pgk config helpers:
```
-- Installing: ${CMAKE_INSTALL_PREFIX}/share/dolfinx_cuas/DOLFINX_CUASConfig.cmake
-- Installing: ${CMAKE_INSTALL_PREFIX}/share/dolfinx_cuas/DOLFINX_CUASConfigVersion.cmake
```
which is used to find the cuas include directories when used in external libraries