### PR TITLE
md span in kernels 

### DIFF
--- a/cpp/QuadratureRule.hpp
+++ b/cpp/QuadratureRule.hpp
@@ -60,6 +60,12 @@ public:
     }
     else
     {
+      namespace stdex = std::experimental;
+      using cmdspan4_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
+      using mdspan4_t = stdex::mdspan<double, stdex::dextents<std::size_t, 4>>;
+      using mdspan2_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
+      using cmdspan2_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
+
       // Create reference topology and geometry
       auto entity_topology = basix::cell::topology(b_ct)[dim];
 
@@ -97,7 +103,10 @@ public:
         _weights.push_back(quadrature[1]);
         xt::xtensor<double, 2> entity_qp
             = xt::zeros<double>({num_pts, static_cast<std::size_t>(coords.shape(1))});
-        dolfinx::math::dot(phi_s, coords, entity_qp);
+
+        dolfinx::math::dot(cmdspan2_t(phi_s.data(), shape[1], shape[2]),
+                           cmdspan2_t(coords.data(), sub_geom.second),
+                           mdspan2_t(entity_qp.data(), num_pts, coords.shape(1)));
         _points.push_back(entity_qp);
       }
     }

--- a/cpp/demo/volume/main.cpp
+++ b/cpp/demo/volume/main.cpp
@@ -40,8 +40,8 @@ int main(int argc, char* argv[])
   {
     const std::string problem_type = vm["kernel"].as<std::string>();
     const int degree = vm["degree"].as<int>();
-
     MPI_Comm mpi_comm{MPI_COMM_WORLD};
+
     std::shared_ptr<mesh::Mesh> mesh = std::make_shared<mesh::Mesh>(
         mesh::create_box(mpi_comm, {{{0.0, 0.0, 0.0}, {1.0, 1.0, 1.0}}}, {10, 10, 10},
                          mesh::CellType::tetrahedron, mesh::GhostMode::none));
@@ -102,6 +102,7 @@ int main(int argc, char* argv[])
     // Generate Kernel
     dolfinx_cuas::QuadratureRule q_rule(mesh->topology().cell_type(), q_degree,
                                         mesh->topology().dim(), basix::quadrature::type::Default);
+
     auto kernel = dolfinx_cuas::generate_kernel<PetscScalar>(kernel_type, degree,
                                                              V->dofmap()->index_map_bs(), q_rule);
 
@@ -139,6 +140,7 @@ int main(int argc, char* argv[])
     if (!dolfinx_cuas::allclose(A.mat(), B.mat()))
       throw std::runtime_error("Matrices are not the same");
   }
+
   PetscFinalize();
   return 0;
 }

--- a/cpp/kernels.hpp
+++ b/cpp/kernels.hpp
@@ -88,8 +88,8 @@ dolfinx_cuas::kernel_fn<T> generate_tet_kernel(dolfinx_cuas::Kernel type,
   assert(basis.extent(3) == 1);
   assert(weights.size() == points.shape(0));
   assert(dphi.extent(0) == points.shape(0));
-  assert(dphi.extent(1) == tdim);
-  assert(dphi.extent(2) == ndofs_cell);
+  assert(dphi.extent(1) == ndofs_cell);
+  assert(dphi.extent(2) == tdim);
   for (std::int32_t k = 0; k < tdim; k++)
     for (std::size_t q = 0; q < weights.size(); q++)
       for (std::int32_t i = 0; i < ndofs_cell; i++)

--- a/cpp/kernels.hpp
+++ b/cpp/kernels.hpp
@@ -74,10 +74,8 @@ dolfinx_cuas::kernel_fn<T> generate_tet_kernel(dolfinx_cuas::Kernel type,
       basix::element::family::P, cell, 1, basix::element::lagrange_variant::gll_warped);
   std::array<std::size_t, 4> tab_shape = coordinate_element.tabulate_shape(1, points.shape(0));
   xt::xtensor<double, 4> coordinate_basis(tab_shape);
-  coordinate_element.tabulate(1, basix::impl::cmdspan2_t(points.data(), pts_shape),
-                              basix::impl::mdspan4_t(coordinate_basis.data(), tab_shape));
-
-  assert(ndofs_cell == static_cast<std::int32_t>(phi.shape(1)));
+  coordinate_element.tabulate(1, cmdspan2_t(points.data(), pts_shape),
+                              mdspan4_t(coordinate_basis.data(), tab_shape));
 
   // Stiffness Matrix using quadrature formulation
   // =====================================================================================
@@ -89,7 +87,7 @@ dolfinx_cuas::kernel_fn<T> generate_tet_kernel(dolfinx_cuas::Kernel type,
       for (std::int32_t i = 0; i < ndofs_cell; i++)
         dphi(q, i, k) = basis(k + 1, q, i, 0);
 
-  std::array<std::size_t, 2> shape = {d, gdim};
+  constexpr std::array<std::size_t, 2> shape = {d, gdim};
   std::array<std::size_t, 2> shape_d = {ndofs_cell, gdim};
   dolfinx_cuas::kernel_fn<T> stiffness
       = [=](T* A, const T* c, const T* w, const double* coordinate_dofs,

--- a/cpp/kernels.hpp
+++ b/cpp/kernels.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Jørgen S. Dokken, Igor A. Baratta, Sarah Roggendorf
+// Copyright (C) 2021-2022 Jørgen S. Dokken, Igor A. Baratta, Sarah Roggendorf
 //
 // This file is part of DOLFINx_CUAS
 //
@@ -41,6 +41,14 @@ template <int P, int bs, typename T>
 dolfinx_cuas::kernel_fn<T> generate_tet_kernel(dolfinx_cuas::Kernel type,
                                                dolfinx_cuas::QuadratureRule& quadrature_rule)
 {
+  namespace stdex = std::experimental;
+  using cmdspan4_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
+  using mdspan4_t = stdex::mdspan<double, stdex::dextents<std::size_t, 4>>;
+  using mdspan2_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
+  using cmdspan2_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
+  using mdspan3_t = stdex::mdspan<double, stdex::dextents<std::size_t, 3>>;
+  using cmdspan3_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 3>>;
+
   // Problem specific parameters
   basix::element::family family = basix::element::family::P;
   basix::cell::type cell = basix::cell::type::tetrahedron;
@@ -56,12 +64,10 @@ dolfinx_cuas::kernel_fn<T> generate_tet_kernel(dolfinx_cuas::Kernel type,
   basix::FiniteElement element
       = basix::create_element(family, cell, P, basix::element::lagrange_variant::gll_warped);
   std::array<std::size_t, 4> basis_shape = element.tabulate_shape(1, points.shape(0));
-  xt::xtensor<double, 4> basis(basis_shape);
+  std::vector<double> basisb(
+      std::reduce(basis_shape.begin(), basis_shape.end(), 1, std::multiplies{}));
   std::array<std::size_t, 2> pts_shape = {points.shape(0), points.shape(1)};
-  element.tabulate(1, basix::impl::cmdspan2_t(points.data(), pts_shape),
-                   basix::impl::mdspan4_t(basis.data(), basis_shape));
-  xt::xtensor<double, 2> phi = xt::view(basis, 0, xt::all(), xt::all(), 0);
-  xt::xtensor<double, 3> dphi = xt::view(basis, xt::range(1, tdim + 1), xt::all(), xt::all(), 0);
+  element.tabulate(1, cmdspan2_t(points.data(), pts_shape), mdspan4_t(basisb.data(), basis_shape));
 
   // Get coordinate element from dolfinx
   basix::FiniteElement coordinate_element = basix::create_element(
@@ -71,19 +77,17 @@ dolfinx_cuas::kernel_fn<T> generate_tet_kernel(dolfinx_cuas::Kernel type,
   coordinate_element.tabulate(1, basix::impl::cmdspan2_t(points.data(), pts_shape),
                               basix::impl::mdspan4_t(coordinate_basis.data(), tab_shape));
 
-  xt::xtensor<double, 2> dphi0_c
-      = xt::view(coordinate_basis, xt::range(1, tdim + 1), 0, xt::all(), 0);
-
   assert(ndofs_cell == static_cast<std::int32_t>(phi.shape(1)));
 
   // Stiffness Matrix using quadrature formulation
   // =====================================================================================
-
-  xt::xtensor<double, 3> _dphi({dphi.shape(1), dphi.shape(2), dphi.shape(0)});
+  cmdspan4_t basis(basisb.data(), basis_shape);
+  std::vector<double> dphib(tdim * basis_shape[1] * basis_shape[2]);
+  mdspan3_t dphi(dphib.data(), tdim, basis_shape[1], basis_shape[2]);
   for (std::int32_t k = 0; k < tdim; k++)
     for (std::size_t q = 0; q < weights.size(); q++)
       for (std::int32_t i = 0; i < ndofs_cell; i++)
-        _dphi(q, i, k) = dphi(k, q, i);
+        dphi(q, i, k) = basis(k + 1, q, i, 0);
 
   std::array<std::size_t, 2> shape = {d, gdim};
   std::array<std::size_t, 2> shape_d = {ndofs_cell, gdim};
@@ -91,27 +95,40 @@ dolfinx_cuas::kernel_fn<T> generate_tet_kernel(dolfinx_cuas::Kernel type,
       = [=](T* A, const T* c, const T* w, const double* coordinate_dofs,
             const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
-    // Get geometrical data
-    xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
-    xt::xtensor<double, 2> K = xt::zeros<double>({tdim, gdim});
-    xt::xtensor<double, 2> coord = xt::adapt(coordinate_dofs, gdim * d, xt::no_ownership(), shape);
-    auto c_view = xt::view(coord, xt::all(), xt::range(0, gdim));
+    // Create buffers for jacobian (inverse and determinant) computations
+    std::vector<double> Jb(gdim * tdim);
+    std::vector<double> Kb(tdim * gdim);
+    mdspan2_t J(Jb.data(), gdim, tdim);
+    mdspan2_t K(Kb.data(), tdim, gdim);
+    cmdspan2_t coords(coordinate_dofs, shape);
+    std::vector<double> detJ_scratch(2 * gdim * tdim);
 
     // Compute Jacobian, its inverse and the determinant
-    dolfinx::fem::CoordinateElement::compute_jacobian(dphi0_c, c_view, J);
-    dolfinx::fem::CoordinateElement::compute_jacobian_inverse(J, K);
-    const double detJ = std::fabs(dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J));
+    cmdspan4_t dphi_c_full(coordinate_basis.data(), tab_shape);
 
-    xt::xtensor<double, 2> dphi_kernel(shape_d);
+    auto dphi_c_0 = stdex::submdspan(dphi_c_full, std::pair(1, tdim + 1), 0, stdex::full_extent, 0);
+    dolfinx::fem::CoordinateElement::compute_jacobian(dphi_c_0, coords, J);
+    dolfinx::fem::CoordinateElement::compute_jacobian_inverse(J, K);
+    const double detJ
+        = std::fabs(dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J, detJ_scratch));
+
+    // Get derivatives of element basis
+    cmdspan3_t dphi(dphib.data(), tdim, basis_shape[1], basis_shape[2]);
+
+    // Create temporary storage for K*dphi_ref
+    std::vector<double> dphi_physb(
+        std::reduce(shape_d.begin(), shape_d.end(), 1, std::multiplies{}));
+    mdspan2_t dphi_phys(dphi_physb.data(), shape_d);
+
     for (std::size_t q = 0; q < weights.size(); q++)
     {
       const double w0 = weights[q] * detJ;
       // precompute J^-T * dphi in temporary array d
-      std::fill(dphi_kernel.begin(), dphi_kernel.end(), 0);
+      std::fill(dphi_physb.begin(), dphi_physb.end(), 0);
       for (int i = 0; i < ndofs_cell; i++)
         for (int j = 0; j < gdim; j++)
           for (int k = 0; k < tdim; k++)
-            dphi_kernel(i, j) += K(k, j) * _dphi(q, i, k);
+            dphi_phys(i, j) += K(k, j) * dphi(q, i, k);
 
       // Special handling of scalar space
       if constexpr (bs == 1)
@@ -120,7 +137,7 @@ dolfinx_cuas::kernel_fn<T> generate_tet_kernel(dolfinx_cuas::Kernel type,
         for (int i = 0; i < ndofs_cell; i++)
           for (int j = 0; j < ndofs_cell; j++)
             for (int k = 0; k < gdim; k++)
-              A[i * ndofs_cell + j] += w0 * dphi_kernel(i, k) * dphi_kernel(j, k);
+              A[i * ndofs_cell + j] += w0 * dphi_phys(i, k) * dphi_phys(j, k);
       }
       else
       {
@@ -132,7 +149,7 @@ dolfinx_cuas::kernel_fn<T> generate_tet_kernel(dolfinx_cuas::Kernel type,
             // Compute block invariant contribution
             double block_invariant = 0;
             for (int k = 0; k < gdim; k++)
-              block_invariant += dphi_kernel(i, k) * dphi_kernel(j, k);
+              block_invariant += dphi_phys(i, k) * dphi_phys(j, k);
             block_invariant *= w0;
 
             // Insert into matrix
@@ -150,15 +167,26 @@ dolfinx_cuas::kernel_fn<T> generate_tet_kernel(dolfinx_cuas::Kernel type,
       = [=](T* A, const T* c, const T* w, const double* coordinate_dofs,
             const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
-    // Get geometrical data
-    xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
-    std::array<std::size_t, 2> shape = {d, gdim};
-    xt::xtensor<double, 2> coord = xt::adapt(coordinate_dofs, gdim * d, xt::no_ownership(), shape);
-    auto c_view = xt::view(coord, xt::all(), xt::range(0, gdim));
+    // Create buffers for jacobian (inverse and determinant) computations
+    std::vector<double> Jb(gdim * tdim);
+    std::vector<double> Kb(tdim * gdim);
+    mdspan2_t J(Jb.data(), gdim, tdim);
+    mdspan2_t K(Kb.data(), tdim, gdim);
+    cmdspan2_t coords(coordinate_dofs, shape);
+    std::vector<double> detJ_scratch(2 * gdim * tdim);
 
     // Compute Jacobian, its inverse and the determinant
-    dolfinx::fem::CoordinateElement::compute_jacobian(dphi0_c, c_view, J);
-    double detJ = std::fabs(dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J));
+    cmdspan4_t dphi_c_full(coordinate_basis.data(), tab_shape);
+
+    auto dphi_c_0 = stdex::submdspan(dphi_c_full, std::pair(1, tdim + 1), 0, stdex::full_extent, 0);
+    dolfinx::fem::CoordinateElement::compute_jacobian(dphi_c_0, coords, J);
+    dolfinx::fem::CoordinateElement::compute_jacobian_inverse(J, K);
+    const double detJ
+        = std::fabs(dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J, detJ_scratch));
+
+    // Get basis function views
+    cmdspan4_t full_basis(basisb.data(), basis_shape);
+    cmdspan2_t phi = stdex::submdspan(full_basis, 0, stdex::full_extent, stdex::full_extent, 0);
 
     // Main loop
     for (std::size_t q = 0; q < weights.size(); q++)
@@ -166,15 +194,15 @@ dolfinx_cuas::kernel_fn<T> generate_tet_kernel(dolfinx_cuas::Kernel type,
       double w0 = weights[q] * detJ;
       for (int i = 0; i < ndofs_cell; i++)
       {
-        double w1 = w0 * phi.unchecked(q, i);
+        double w1 = w0 * phi(q, i);
         for (int j = 0; j < ndofs_cell; j++)
         {
           // Special handling of scalar space
           if constexpr (bs == 1)
-            A[i * ndofs_cell + j] += w1 * phi.unchecked(q, j);
+            A[i * ndofs_cell + j] += w1 * phi(q, j);
           else
             for (int b = 0; b < bs; b++)
-              A[(i * bs + b) * (ndofs_cell * bs) + bs * j + b] += w1 * phi.unchecked(q, j);
+              A[(i * bs + b) * (ndofs_cell * bs) + bs * j + b] += w1 * phi(q, j);
         }
       }
     }
@@ -184,7 +212,10 @@ dolfinx_cuas::kernel_fn<T> generate_tet_kernel(dolfinx_cuas::Kernel type,
   // =====================================================================================
 
   // Pre-compute local matrix for reference element
-  xt::xtensor<double, 2> A0 = xt::zeros<double>({ndofs_cell, ndofs_cell});
+  cmdspan4_t full_basis(basisb.data(), basis_shape);
+  cmdspan2_t phi = stdex::submdspan(full_basis, 0, stdex::full_extent, stdex::full_extent, 0);
+  std::vector<double> A0b(ndofs_cell * ndofs_cell);
+  mdspan2_t A0(A0b.data(), ndofs_cell, ndofs_cell);
   for (std::size_t q = 0; q < weights.size(); q++)
     for (int i = 0; i < ndofs_cell; i++)
       for (int j = 0; j < ndofs_cell; j++)
@@ -194,19 +225,27 @@ dolfinx_cuas::kernel_fn<T> generate_tet_kernel(dolfinx_cuas::Kernel type,
       = [=](T* A, const T* c, const T* w, const double* coordinate_dofs,
             const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
-    // Get geometrical data
-    xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
-    std::array<std::size_t, 2> shape = {d, gdim};
-    xt::xtensor<double, 2> coord = xt::adapt(coordinate_dofs, gdim * d, xt::no_ownership(), shape);
-    auto c_view = xt::view(coord, xt::all(), xt::range(0, gdim));
+    // Create buffers for jacobian (inverse and determinant) computations
+    std::vector<double> Jb(gdim * tdim);
+    std::vector<double> Kb(tdim * gdim);
+    mdspan2_t J(Jb.data(), gdim, tdim);
+    mdspan2_t K(Kb.data(), tdim, gdim);
+    cmdspan2_t coords(coordinate_dofs, shape);
+    std::vector<double> detJ_scratch(2 * gdim * tdim);
 
     // Compute Jacobian, its inverse and the determinant
-    dolfinx::fem::CoordinateElement::compute_jacobian(dphi0_c, c_view, J);
-    double detJ = std::fabs(dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J));
+    cmdspan4_t dphi_c_full(coordinate_basis.data(), tab_shape);
 
+    auto dphi_c_0 = stdex::submdspan(dphi_c_full, std::pair(1, tdim + 1), 0, stdex::full_extent, 0);
+    dolfinx::fem::CoordinateElement::compute_jacobian(dphi_c_0, coords, J);
+    dolfinx::fem::CoordinateElement::compute_jacobian_inverse(J, K);
+    const double detJ
+        = std::fabs(dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J, detJ_scratch));
+
+    cmdspan2_t A0(A0b.data(), (std::size_t)ndofs_cell, (std::size_t)ndofs_cell);
     for (int i = 0; i < ndofs_cell; i++)
       for (int j = 0; j < ndofs_cell; j++)
-        A[i * ndofs_cell + j] += detJ * A0.unchecked(i, j);
+        A[i * ndofs_cell + j] += detJ * A0(i, j);
   };
 
   // Tr(eps(u))I:eps(v) dx
@@ -216,20 +255,31 @@ dolfinx_cuas::kernel_fn<T> generate_tet_kernel(dolfinx_cuas::Kernel type,
             const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
     assert(bs == 3);
-    // Get geometrical data
-    xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
-    xt::xtensor<double, 2> K = xt::zeros<double>({tdim, gdim});
-    std::array<std::size_t, 2> shape = {d, gdim};
-    xt::xtensor<double, 2> coord = xt::adapt(coordinate_dofs, gdim * d, xt::no_ownership(), shape);
+
+    // Create buffers for jacobian (inverse and determinant) computations
+    std::vector<double> Jb(gdim * tdim);
+    std::vector<double> Kb(tdim * gdim);
+    mdspan2_t J(Jb.data(), gdim, tdim);
+    mdspan2_t K(Kb.data(), tdim, gdim);
+    cmdspan2_t coords(coordinate_dofs, shape);
+    std::vector<double> detJ_scratch(2 * gdim * tdim);
 
     // Compute Jacobian, its inverse and the determinant
-    auto c_view = xt::view(coord, xt::all(), xt::range(0, gdim));
-    dolfinx::fem::CoordinateElement::compute_jacobian(dphi0_c, c_view, J);
+    cmdspan4_t dphi_c_full(coordinate_basis.data(), tab_shape);
+
+    auto dphi_c_0 = stdex::submdspan(dphi_c_full, std::pair(1, tdim + 1), 0, stdex::full_extent, 0);
+    dolfinx::fem::CoordinateElement::compute_jacobian(dphi_c_0, coords, J);
     dolfinx::fem::CoordinateElement::compute_jacobian_inverse(J, K);
-    double detJ = std::fabs(dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J));
+    const double detJ
+        = std::fabs(dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J, detJ_scratch));
+
+    // Get derivatives of element basis
+    cmdspan3_t dphi(dphib.data(), tdim, basis_shape[1], basis_shape[2]);
 
     // Temporary variable for grad(phi) on physical cell
-    xt::xtensor<double, 2> dphi_phys({bs, ndofs_cell});
+    std::vector<double> dphi_physb(
+        std::reduce(shape_d.begin(), shape_d.end(), 1, std::multiplies{}));
+    mdspan2_t dphi_phys(dphi_physb.data(), shape_d[1], shape_d[0]);
 
     // Main loop
     for (std::size_t q = 0; q < weights.size(); q++)
@@ -237,11 +287,11 @@ dolfinx_cuas::kernel_fn<T> generate_tet_kernel(dolfinx_cuas::Kernel type,
       double w0 = weights[q] * detJ;
 
       // Precompute J^-T * dphi
-      std::fill(dphi_phys.begin(), dphi_phys.end(), 0);
+      std::fill(dphi_physb.begin(), dphi_physb.end(), 0);
       for (int i = 0; i < ndofs_cell; i++)
         for (int j = 0; j < bs; j++)
           for (int k = 0; k < tdim; k++)
-            dphi_phys(j, i) += K(k, j) * _dphi(q, i, k);
+            dphi_phys(j, i) += K(k, j) * dphi(q, i, k);
 
       // Add contributions to local matrix
       for (int i = 0; i < ndofs_cell; i++)
@@ -270,34 +320,44 @@ dolfinx_cuas::kernel_fn<T> generate_tet_kernel(dolfinx_cuas::Kernel type,
             const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
     assert(bs == 3);
-    // Get geometrical data
-    xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
-    xt::xtensor<double, 2> K = xt::zeros<double>({tdim, gdim});
-    std::array<std::size_t, 2> shape = {d, gdim};
-    xt::xtensor<double, 2> coord = xt::adapt(coordinate_dofs, gdim * d, xt::no_ownership(), shape);
+    // Create buffers for jacobian (inverse and determinant) computations
+    std::vector<double> Jb(gdim * tdim);
+    std::vector<double> Kb(tdim * gdim);
+    mdspan2_t J(Jb.data(), gdim, tdim);
+    mdspan2_t K(Kb.data(), tdim, gdim);
+    cmdspan2_t coords(coordinate_dofs, shape);
+    std::vector<double> detJ_scratch(2 * gdim * tdim);
 
     // Compute Jacobian, its inverse and the determinant
-    auto c_view = xt::view(coord, xt::all(), xt::range(0, gdim));
-    dolfinx::fem::CoordinateElement::compute_jacobian(dphi0_c, c_view, J);
+    cmdspan4_t dphi_c_full(coordinate_basis.data(), tab_shape);
+
+    auto dphi_c_0 = stdex::submdspan(dphi_c_full, std::pair(1, tdim + 1), 0, stdex::full_extent, 0);
+    dolfinx::fem::CoordinateElement::compute_jacobian(dphi_c_0, coords, J);
     dolfinx::fem::CoordinateElement::compute_jacobian_inverse(J, K);
-    double detJ = std::fabs(dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J));
+    const double detJ
+        = std::fabs(dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J, detJ_scratch));
+
+    // Get derivatives of element basis
+    cmdspan3_t dphi(dphib.data(), tdim, basis_shape[1], basis_shape[2]);
 
     // Temporary variable for grad(phi) on physical cell
-    xt::xtensor<double, 2> dphi_phys({ndofs_cell, bs});
+    std::vector<double> dphi_physb(
+        std::reduce(shape_d.begin(), shape_d.end(), 1, std::multiplies{}));
+    mdspan2_t dphi_phys(dphi_physb.data(), shape_d);
 
     // Main loop
     for (std::size_t q = 0; q < weights.size(); q++)
     {
       const double w0 = weights[q] * detJ;
       // Precompute J^-T * dphi
-      std::fill(dphi_phys.begin(), dphi_phys.end(), 0);
+      std::fill(dphi_physb.begin(), dphi_physb.end(), 0);
       for (int i = 0; i < ndofs_cell; i++)
       {
         for (int j = 0; j < bs; j++)
         {
           double acc = 0;
           for (int k = 0; k < tdim; k++)
-            acc += K(k, j) * _dphi(q, i, k);
+            acc += K(k, j) * dphi(q, i, k);
           dphi_phys(i, j) += acc;
         }
       }

--- a/cpp/surface_kernels.hpp
+++ b/cpp/surface_kernels.hpp
@@ -13,7 +13,6 @@
 #include <dolfinx/common/math.h>
 #include <dolfinx/fem/FiniteElement.h>
 #include <dolfinx/fem/FunctionSpace.h>
-#include <xtensor/xadapt.hpp>
 
 namespace dolfinx_cuas
 {
@@ -23,17 +22,24 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
                                      dolfinx_cuas::Kernel type,
                                      dolfinx_cuas::QuadratureRule& quadrature_rule)
 {
+  namespace stdex = std::experimental;
+  using cmdspan4_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 4>>;
+  using mdspan4_t = stdex::mdspan<double, stdex::dextents<std::size_t, 4>>;
+  using mdspan2_t = stdex::mdspan<double, stdex::dextents<std::size_t, 2>>;
+  using cmdspan2_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 2>>;
+  using mdspan3_t = stdex::mdspan<double, stdex::dextents<std::size_t, 3>>;
+  using cmdspan3_t = stdex::mdspan<const double, stdex::dextents<std::size_t, 3>>;
 
   auto mesh = V->mesh();
-
+  assert(mesh);
   // Get mesh info
   const int gdim = mesh->geometry().dim(); // geometrical dimension
   const int tdim = mesh->topology().dim(); // topological dimension
   const int fdim = tdim - 1;               // topological dimension of facet
 
   // Create coordinate elements for cell
-  const basix::FiniteElement basix_element = mesh_to_basix_element(mesh, tdim);
-  const int num_coordinate_dofs = basix_element.dim();
+  const dolfinx::fem::CoordinateElement cmap = mesh->geometry().cmap();
+  const int num_coordinate_dofs = cmap.dim();
 
   // Create quadrature points on reference facet
   const std::vector<xt::xtensor<double, 2>>& q_points = quadrature_rule.points_ref();
@@ -46,12 +52,8 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
   std::shared_ptr<const dolfinx::fem::FiniteElement> element = V->element();
   int bs = element->block_size();
   std::uint32_t num_local_dofs = element->space_dimension() / bs;
-  std::vector<xt::xtensor<double, 2>> phi;
-  phi.reserve(num_facets);
-  std::vector<xt::xtensor<double, 3>> dphi;
-  phi.reserve(num_facets);
-  std::vector<xt ::xtensor<double, 3>> dphi_c;
-  dphi_c.reserve(num_facets);
+  std::vector<std::pair<std::vector<double>, std::array<std::size_t, 4>>> basis_values;
+  std::vector<std::pair<std::vector<double>, std::array<std::size_t, 4>>> coordinate_basis_values;
 
   // Tabulate basis functions (for test/trial function) and coordinate element at
   // quadrature points
@@ -59,67 +61,89 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
   {
     const xt::xtensor<double, 2>& q_facet = q_points[i];
     const int num_quadrature_points = q_facet.shape(0);
-    xt::xtensor<double, 4> cell_tab({tdim + 1, num_quadrature_points, num_local_dofs, 1});
+
+    const std::array<std::size_t, 4> e_shape
+        = element->basix_element().tabulate_shape(1, num_quadrature_points);
+    assert(e_shape.back() == 1);
+    basis_values.push_back(
+        {std::vector<double>(std::reduce(e_shape.begin(), e_shape.end(), 1, std::multiplies())),
+         e_shape});
 
     // Tabulate at quadrature points on facet
-    element->tabulate(cell_tab, q_facet, 1);
-    xt::xtensor<double, 2> phi_i = xt::view(cell_tab, 0, xt::all(), xt::all(), 0);
-    phi.push_back(phi_i);
-    xt::xtensor<double, 3> dphi_i
-        = xt::view(cell_tab, xt::range(1, tdim + 1), xt::all(), xt::all(), 0);
-    dphi.push_back(dphi_i);
+    std::vector<double>& basis = basis_values.back().first;
+    element->tabulate(basis, std::span(q_facet.data(), q_facet.size()), q_facet.shape(), 1);
 
     // Tabulate coordinate element of reference cell
-    std::array<std::size_t, 4> tab_shape = basix_element.tabulate_shape(1, q_facet.shape(0));
-    std::array<std::size_t, 2> pts_shape = {q_facet.shape(0), q_facet.shape(1)};
-    xt::xtensor<double, 4> c_tab(tab_shape);
-    basix_element.tabulate(1, basix::impl::cmdspan2_t(q_facet.data(), pts_shape),
-                           basix::impl::mdspan4_t(c_tab.data(), tab_shape));
-    xt::xtensor<double, 3> dphi_ci
-        = xt::view(c_tab, xt::range(1, tdim + 1), xt::all(), xt::all(), 0);
-    dphi_c.push_back(dphi_ci);
+    std::array<std::size_t, 4> tab_shape = cmap.tabulate_shape(1, q_facet.shape(0));
+    coordinate_basis_values.push_back(
+        {std::vector<double>(std::reduce(tab_shape.begin(), tab_shape.end(), 1, std::multiplies())),
+         tab_shape});
+    std::vector<double>& cbasis = coordinate_basis_values.back().first;
+    cmap.tabulate(1, std::span(q_facet.data(), q_facet.size()), q_facet.shape(), cbasis);
   }
 
   // As reference facet and reference cell are affine, we do not need to compute this per
   // quadrature point
-  auto [ref_jac, jac_shape] = basix::cell::facet_jacobians(basix_element.cell_type());
-  xt::xtensor<double, 3> ref_jacobians(jac_shape);
-  std::copy(ref_jac.cbegin(), ref_jac.cend(), ref_jacobians.begin());
+  basix::cell::type basix_cell
+      = dolfinx::mesh::cell_type_to_basix_type(mesh->topology().cell_type());
+  std::pair<std::vector<double>, std::array<std::size_t, 3>> jacobians
+      = basix::cell::facet_jacobians(basix_cell);
+  auto ref_jac = jacobians.first;
+  auto jac_shape = jacobians.second;
 
   // Get facet normals on reference cell
-  auto [_facet_normals, n_shape] = basix::cell::facet_outward_normals(basix_element.cell_type());
-  xt::xtensor<double, 2> facet_normals(n_shape);
-  std::copy(_facet_normals.cbegin(), _facet_normals.cend(), facet_normals.begin());
+  std::pair<std::vector<double>, std::array<std::size_t, 2>> normals
+      = basix::cell::facet_outward_normals(basix_cell);
+  auto facet_normals = normals.first;
+  auto normal_shape = normals.second;
 
+  const bool is_affine = cmap.is_affine();
   // Define kernels
   kernel_fn<T> mass = [=](T* A, const T* c, const T* w, const double* coordinate_dofs,
                           const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
     std::size_t facet_index = size_t(*entity_local_index);
 
-    // Reshape coordinate dofs to two dimensional array
-    // NOTE: DOLFINx has 3D input coordinate dofs
-    std::array<std::size_t, 2> shape = {num_coordinate_dofs, 3};
-    const xt::xtensor<double, 2> coord
-        = xt::adapt(coordinate_dofs, num_coordinate_dofs * 3, xt::no_ownership(), shape);
-    auto c_view = xt::view(coord, xt::all(), xt::range(0, gdim));
-    const xt::xtensor<double, 3>& dphi_fc = dphi_c[facet_index];
-    const xt::xtensor<double, 2>& dphi0_c
-        = xt::view(dphi_fc, xt::all(), 0,
-                   xt::all()); // FIXME: Assumed constant, i.e. only works for simplices
-    // Compute Jacobian and determinant at each quadrature point
-    xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
-    dolfinx::fem::CoordinateElement::compute_jacobian(dphi0_c, c_view, J);
-    const xt::xtensor<double, 2>& J_f = xt::view(ref_jacobians, facet_index, xt::all(), xt::all());
+    // Get basis values
+    auto [basis, shape] = basis_values[facet_index];
+    auto [cbasis, cshape] = coordinate_basis_values[facet_index];
 
-    xt::xtensor<double, 2> J_tot = xt::zeros<double>({J.shape(0), J_f.shape(1)});
+    // Reshape coordinate dofs
+    cmdspan2_t coords(coordinate_dofs, std::array<std::size_t, 2>{num_coordinate_dofs, gdim});
+    auto c_view = stdex::submdspan(coords, stdex::full_extent, std::pair{1, gdim});
+
+    //  FIXME: Assumed constant, i.e. only works for simplices
+    assert(is_affine);
+
+    // Compute Jacobian and determinant on facet
+    std::vector<double> Jb(gdim * tdim);
+    std::vector<double> Kb(tdim * gdim);
+    mdspan2_t J(Jb.data(), gdim, tdim);
+    mdspan2_t K(Kb.data(), tdim, gdim);
+    std::vector<double> detJ_scratch(2 * gdim * tdim);
+    cmdspan4_t phi_c_full(cbasis.data(), cshape);
+    auto dphi_c_0 = stdex::submdspan(phi_c_full, std::pair(1, tdim + 1), 0, stdex::full_extent, 0);
+    dolfinx::fem::CoordinateElement::compute_jacobian(dphi_c_0, c_view, J);
+    dolfinx::fem::CoordinateElement::compute_jacobian_inverse(J, K);
+
+    // Extract reference Jacobian at facet
+    cmdspan3_t reference_jacobians(ref_jac.data(), jac_shape);
+    auto J_f = stdex::submdspan(reference_jacobians, facet_index, stdex::full_extent,
+                                stdex::full_extent);
+    std::vector<double> J_totb(J.extent(0) * J_f.extent(1));
+    mdspan2_t J_tot(J_totb.data(), J.extent(0), J_f.extent(1));
     dolfinx::math::dot(J, J_f, J_tot);
 
-    const double detJ
-        = std::fabs(dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J_tot));
+    const double detJ = std::fabs(
+        dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J_tot, detJ_scratch));
+
     // Get number of dofs per cell
     const std::vector<double>& weights = q_weights[facet_index];
-    const xt::xtensor<double, 2>& phi_f = phi[facet_index];
+
+    // Extract basis values of test/trial function
+    cmdspan4_t phi_full(basis.data(), shape);
+    auto phi_f = stdex::submdspan(phi_full, 0, stdex::full_extent, stdex::full_extent, 0);
+
     // Loop over quadrature points
     for (std::size_t q = 0; q < weights.size(); q++)
     {
@@ -149,21 +173,35 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
   {
     std::size_t facet_index = size_t(*entity_local_index);
 
-    // Reshape coordinate dofs to two dimensional array
-    // NOTE: DOLFINx has 3D input coordinate dofs
-    std::array<std::size_t, 2> shape = {num_coordinate_dofs, 3};
-    const xt::xtensor<double, 2>& coord
-        = xt::adapt(coordinate_dofs, num_coordinate_dofs * 3, xt::no_ownership(), shape);
-    auto c_view = xt::view(coord, xt::all(), xt::range(0, gdim));
+    // Get basis values
+    auto [basis, shape] = basis_values[facet_index];
+    auto [cbasis, cshape] = coordinate_basis_values[facet_index];
 
-    // Compute Jacobian and determinant at each quadrature point
-    xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
-    const xt::xtensor<double, 2>& J_f = xt::view(ref_jacobians, facet_index, xt::all(), xt::all());
+    // Reshape coordinate dofs
+    cmdspan2_t coords(coordinate_dofs, std::array<std::size_t, 2>{num_coordinate_dofs, gdim});
+    auto c_view = stdex::submdspan(coords, stdex::full_extent, std::pair{1, gdim});
 
+    // Compute Jacobian and determinant on facet
+    std::vector<double> Jb(gdim * tdim);
+    std::vector<double> Kb(tdim * gdim);
+    mdspan2_t J(Jb.data(), gdim, tdim);
+    mdspan2_t K(Kb.data(), tdim, gdim);
+    std::vector<double> detJ_scratch(2 * gdim * tdim);
+
+    // Extract reference Jacobian at facet
+    cmdspan3_t reference_jacobians(ref_jac.data(), jac_shape);
+    auto J_f = stdex::submdspan(reference_jacobians, facet_index, stdex::full_extent,
+                                stdex::full_extent);
+    std::vector<double> J_totb(J.extent(0) * J_f.extent(1));
+    mdspan2_t J_tot(J_totb.data(), J.extent(0), J_f.extent(1));
+
+    // Get number of dofs per cell
     const std::vector<double>& weights = q_weights[facet_index];
-    const xt::xtensor<double, 2>& phi_f = phi[facet_index];
-    const xt::xtensor<double, 3>& dphi_fc = dphi_c[facet_index];
-    xt::xtensor<double, 2> J_tot = xt::zeros<double>({J.shape(0), J_f.shape(1)});
+
+    // Extract basis values of test/trial function
+    cmdspan4_t phi_full(basis.data(), shape);
+    auto phi_f = stdex::submdspan(phi_full, 0, stdex::full_extent, stdex::full_extent, 0);
+    cmdspan4_t phi_c_full(cbasis.data(), cshape);
 
     // Loop over quadrature points
     for (std::size_t q = 0; q < weights.size(); q++)
@@ -171,15 +209,18 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
 
       // Extract the first derivative of the coordinate element (cell) of degrees of freedom
       // on the facet
-      const xt::xtensor<double, 2>& dphi_c_q = xt::view(dphi_fc, xt::all(), q, xt::all());
-      J.fill(0);
+
+      auto dphi_c_q
+          = stdex::submdspan(phi_c_full, std::pair(1, tdim + 1), q, stdex::full_extent, 0);
+      std::fill(Jb.begin(), Jb.end(), 0);
       dolfinx::fem::CoordinateElement::compute_jacobian(dphi_c_q, c_view, J);
 
-      // Compute det(J_C J_f) as it is the mapping to the reference facet
-      J_tot.fill(0);
-
+      dolfinx::fem::CoordinateElement::compute_jacobian_inverse(J, K);
+      std::fill(J_totb.begin(), J_totb.end(), 0);
       dolfinx::math::dot(J, J_f, J_tot);
-      double detJ = std::fabs(dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J_tot));
+
+      const double detJ = std::fabs(
+          dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J_tot, detJ_scratch));
 
       // Scale at each quadrature point
       const double w0 = weights[q] * detJ;
@@ -200,43 +241,57 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
       }
     }
   };
+
   // FIXME: Template over gdim and tdim?
   kernel_fn<T> stiffness
       = [=](T* A, const T* c, const T* w, const double* coordinate_dofs,
             const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
     std::size_t facet_index = size_t(*entity_local_index);
-    // Reshape coordinate dofs to two dimensional array
-    // NOTE: DOLFINx has 3D input coordinate dofs
-    std::array<std::size_t, 2> shape = {num_coordinate_dofs, 3};
-    auto coord = xt::adapt(coordinate_dofs, num_coordinate_dofs * 3, xt::no_ownership(), shape);
-    auto c_view = xt::view(coord, xt::all(), xt::range(0, gdim));
 
-    // Extract the first derivative of the coordinate element (cell) of degrees of freedom on
-    // the facet
-    const xt::xtensor<double, 3>& dphi_fc = dphi_c[facet_index];
-    auto dphi0_c = xt::view(dphi_fc, xt::all(), 0,
-                            xt::all()); // FIXME: Assumed constant, i.e. only works for simplices
+    // Get basis values
+    auto [basis, shape] = basis_values[facet_index];
+    auto [cbasis, cshape] = coordinate_basis_values[facet_index];
 
-    // Compute Jacobian and inverse of cell mapping at each quadrature point
-    xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
-    xt::xtensor<double, 2> K = xt::zeros<double>({tdim, gdim});
-    dolfinx::fem::CoordinateElement::compute_jacobian(dphi0_c, c_view, J);
+    // Reshape coordinate dofs
+    cmdspan2_t coords(coordinate_dofs, std::array<std::size_t, 2>{num_coordinate_dofs, gdim});
+    auto c_view = stdex::submdspan(coords, stdex::full_extent, std::pair{1, gdim});
+
+    //  FIXME: Assumed constant, i.e. only works for simplices
+    assert(is_affine);
+
+    // Compute Jacobian and determinant on facet
+    std::vector<double> Jb(gdim * tdim);
+    std::vector<double> Kb(tdim * gdim);
+    mdspan2_t J(Jb.data(), gdim, tdim);
+    mdspan2_t K(Kb.data(), tdim, gdim);
+    std::vector<double> detJ_scratch(2 * gdim * tdim);
+    cmdspan4_t phi_c_full(cbasis.data(), cshape);
+    auto dphi_c_0 = stdex::submdspan(phi_c_full, std::pair(1, tdim + 1), 0, stdex::full_extent, 0);
+    dolfinx::fem::CoordinateElement::compute_jacobian(dphi_c_0, c_view, J);
     dolfinx::fem::CoordinateElement::compute_jacobian_inverse(J, K);
 
-    // Compute det(J_C J_f) as it is the mapping to the reference facet
-    auto J_f = xt::view(ref_jacobians, facet_index, xt::all(), xt::all());
-    xt::xtensor<double, 2> J_tot = xt::zeros<double>({J.shape(0), J_f.shape(1)});
+    // Extract reference Jacobian at facet
+    cmdspan3_t reference_jacobians(ref_jac.data(), jac_shape);
+    auto J_f = stdex::submdspan(reference_jacobians, facet_index, stdex::full_extent,
+                                stdex::full_extent);
+    std::vector<double> J_totb(J.extent(0) * J_f.extent(1));
+    mdspan2_t J_tot(J_totb.data(), J.extent(0), J_f.extent(1));
     dolfinx::math::dot(J, J_f, J_tot);
-    double detJ = std::fabs(dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J_tot));
 
-    // Temporary variable for grad(phi) on physical cell
-    xt::xtensor<double, 2> dphi_phys({gdim, num_local_dofs});
+    const double detJ = std::fabs(
+        dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J_tot, detJ_scratch));
 
+    // Get number of dofs per cell
     const std::vector<double>& weights = q_weights[facet_index];
-    const xt::xtensor<double, 2>& phi_f = phi[facet_index];
-    const xt::xtensor<double, 3>& dphi_f = dphi[facet_index];
 
+    // Extract basis values of test/trial function
+    cmdspan4_t phi_full(basis.data(), shape);
+    auto dphi_f = stdex::submdspan(phi_full, std::pair(1, tdim + 1), stdex::full_extent,
+                                   stdex::full_extent, 0);
+
+    std::vector<double> dphi_physb(gdim * shape[2]);
+    mdspan2_t dphi_phys(dphi_physb.data(), gdim, shape[2]);
     // Loop over quadrature points.
     for (std::size_t q = 0; q < weights.size(); q++)
     {
@@ -244,7 +299,7 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
       const double w0 = weights[q] * detJ;
 
       // Precompute J^-T * dphi
-      std::fill(dphi_phys.begin(), dphi_phys.end(), 0);
+      std::fill(dphi_physb.begin(), dphi_physb.end(), 0);
       for (int i = 0; i < num_local_dofs; i++)
         for (int k = 0; k < tdim; k++)
           for (int j = 0; j < gdim; j++)
@@ -270,38 +325,51 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
             const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
     std::size_t facet_index = size_t(*entity_local_index);
-    // Reshape coordinate dofs to two dimensional array
-    // NOTE: DOLFINx assumes 3D coordinate dofs input
-    std::array<std::size_t, 2> shape = {num_coordinate_dofs, 3};
-    auto coord = xt::adapt(coordinate_dofs, num_coordinate_dofs * 3, xt::no_ownership(), shape);
-    auto c_view = xt::view(coord, xt::all(), xt::range(0, gdim));
+    assert(is_affine);
 
-    // Extract the first derivative of the coordinate element(cell) of degrees of freedom on
-    // the facet
-    const xt::xtensor<double, 3>& dphi_cf = dphi_c[facet_index];
-    auto dphi0_c
-        = xt::view(dphi_cf, xt::all(), 0,
-                   xt::all()); // dphi_cf FIXME: Assumed constant, i.e. only works for simplices
+    // Get basis values
+    auto [basis, shape] = basis_values[facet_index];
+    auto [cbasis, cshape] = coordinate_basis_values[facet_index];
 
-    // Compute Jacobian and inverse of cell mapping at each quadrature point
-    xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
-    xt::xtensor<double, 2> K = xt::zeros<double>({tdim, gdim});
-    dolfinx::fem::CoordinateElement::compute_jacobian(dphi0_c, c_view, J);
+    // Reshape coordinate dofs
+    cmdspan2_t coords(coordinate_dofs, std::array<std::size_t, 2>{num_coordinate_dofs, gdim});
+    auto c_view = stdex::submdspan(coords, stdex::full_extent, std::pair{1, gdim});
+
+    //  FIXME: Assumed constant, i.e. only works for simplices
+    assert(is_affine);
+
+    // Compute Jacobian and determinant on facet
+    std::vector<double> Jb(gdim * tdim);
+    std::vector<double> Kb(tdim * gdim);
+    mdspan2_t J(Jb.data(), gdim, tdim);
+    mdspan2_t K(Kb.data(), tdim, gdim);
+    std::vector<double> detJ_scratch(2 * gdim * tdim);
+    cmdspan4_t phi_c_full(cbasis.data(), cshape);
+    auto dphi_c_0 = stdex::submdspan(phi_c_full, std::pair(1, tdim + 1), 0, stdex::full_extent, 0);
+    dolfinx::fem::CoordinateElement::compute_jacobian(dphi_c_0, c_view, J);
     dolfinx::fem::CoordinateElement::compute_jacobian_inverse(J, K);
 
-    // Compute det(J_C J_f) as it is the mapping to the reference facet
-    xt::xtensor<double, 2> J_f = xt::view(ref_jacobians, facet_index, xt::all(), xt::all());
-    xt::xtensor<double, 2> J_tot = xt::zeros<double>({J.shape(0), J_f.shape(1)});
+    // Extract reference Jacobian at facet
+    cmdspan3_t reference_jacobians(ref_jac.data(), jac_shape);
+    auto J_f = stdex::submdspan(reference_jacobians, facet_index, stdex::full_extent,
+                                stdex::full_extent);
+    std::vector<double> J_totb(J.extent(0) * J_f.extent(1));
+    mdspan2_t J_tot(J_totb.data(), J.extent(0), J_f.extent(1));
     dolfinx::math::dot(J, J_f, J_tot);
-    double detJ = std::fabs(dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J_tot));
 
-    // Temporary variable for grad(phi) on physical cell
-    xt::xtensor<double, 2> dphi_phys({gdim, num_local_dofs});
+    const double detJ = std::fabs(
+        dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J_tot, detJ_scratch));
 
-    // Get tables for facet
+    // Get number of dofs per cell
     const std::vector<double>& weights = q_weights[facet_index];
-    const xt::xtensor<double, 2>& phi_f = phi[facet_index];
-    const xt::xtensor<double, 3>& dphi_f = dphi[facet_index];
+
+    // Extract basis values of test/trial function
+    cmdspan4_t phi_full(basis.data(), shape);
+    auto dphi_f = stdex::submdspan(phi_full, std::pair(1, tdim + 1), stdex::full_extent,
+                                   stdex::full_extent, 0);
+
+    std::vector<double> dphi_physb(gdim * shape[2]);
+    mdspan2_t dphi_phys(dphi_physb.data(), gdim, shape[2]);
 
     // Loop over quadrature points
     for (std::size_t q = 0; q < weights.size(); q++)
@@ -310,7 +378,7 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
       const double w0 = weights[q] * detJ;
 
       // Precompute J^-T * dphi
-      std::fill(dphi_phys.begin(), dphi_phys.end(), 0);
+      std::fill(dphi_physb.begin(), dphi_physb.end(), 0);
       for (int i = 0; i < num_local_dofs; i++)
         for (int j = 0; j < gdim; j++)
           for (int k = 0; k < tdim; k++)
@@ -348,51 +416,64 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
   {
     assert(bs == tdim);
     std::size_t facet_index = size_t(*entity_local_index);
-    // Reshape coordinate dofs to two dimensional array
-    // NOTE: DOLFINx assumes 3D coordinate dofs input
-    std::array<std::size_t, 2> shape = {num_coordinate_dofs, 3};
-    xt::xtensor<double, 2> coord
-        = xt::adapt(coordinate_dofs, num_coordinate_dofs * 3, xt::no_ownership(), shape);
-    auto c_view = xt::view(coord, xt::all(), xt::range(0, gdim));
+    assert(is_affine);
 
-    // Extract the first derivative of the coordinate element(cell) of degrees of freedom on
-    // the facet
-    const xt::xtensor<double, 3> dphi_cf = dphi_c[facet_index];
-    auto dphi0_c = xt::view(dphi_cf, xt::all(), 0,
-                            xt::all()); // FIXME: Assumed constant, i.e. only works for simplices
+    // Get basis values
+    auto [basis, shape] = basis_values[facet_index];
+    auto [cbasis, cshape] = coordinate_basis_values[facet_index];
 
-    // Compute Jacobian and inverse of cell mapping at each quadrature point
-    xt::xtensor<double, 2> J = xt::zeros<double>({gdim, tdim});
-    xt::xtensor<double, 2> K = xt::zeros<double>({tdim, gdim});
-    dolfinx::fem::CoordinateElement::compute_jacobian(dphi0_c, c_view, J);
+    // Reshape coordinate dofs
+    cmdspan2_t coords(coordinate_dofs, std::array<std::size_t, 2>{num_coordinate_dofs, gdim});
+    auto c_view = stdex::submdspan(coords, stdex::full_extent, std::pair{1, gdim});
+
+    //  FIXME: Assumed constant, i.e. only works for simplices
+    assert(is_affine);
+
+    // Compute Jacobian and determinant on facet
+    std::vector<double> Jb(gdim * tdim);
+    std::vector<double> Kb(tdim * gdim);
+    mdspan2_t J(Jb.data(), gdim, tdim);
+    mdspan2_t K(Kb.data(), tdim, gdim);
+    std::vector<double> detJ_scratch(2 * gdim * tdim);
+    cmdspan4_t phi_c_full(cbasis.data(), cshape);
+    auto dphi_c_0 = stdex::submdspan(phi_c_full, std::pair(1, tdim + 1), 0, stdex::full_extent, 0);
+    dolfinx::fem::CoordinateElement::compute_jacobian(dphi_c_0, c_view, J);
     dolfinx::fem::CoordinateElement::compute_jacobian_inverse(J, K);
 
+    // Extract reference Jacobian at facet
+    cmdspan3_t reference_jacobians(ref_jac.data(), jac_shape);
+    auto J_f = stdex::submdspan(reference_jacobians, facet_index, stdex::full_extent,
+                                stdex::full_extent);
+    std::vector<double> J_totb(J.extent(0) * J_f.extent(1));
+    mdspan2_t J_tot(J_totb.data(), J.extent(0), J_f.extent(1));
+    dolfinx::math::dot(J, J_f, J_tot);
+    const double detJ = std::fabs(
+        dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J_tot, detJ_scratch));
     // Compute normal of physical facet using a normalized covariant Piola transform
     // n_phys = J^{-T} n_ref / ||J^{-T} n_ref||
     // See for instance DOI: 10.1137/08073901X
-    xt::xarray<double> n_phys = xt::zeros<double>({gdim});
-    auto facet_normal = xt::row(facet_normals, facet_index);
+    cmdspan2_t normals_f(facet_normals.data(), normal_shape);
+    std::vector<double> n_phys(gdim);
     for (std::size_t i = 0; i < gdim; i++)
       for (std::size_t j = 0; j < tdim; j++)
-        n_phys[i] += K(j, i) * facet_normal[j];
+        n_phys[i] += K(j, i) * normals_f(facet_index, j);
     double n_norm = 0;
     for (std::size_t i = 0; i < gdim; i++)
       n_norm += n_phys[i] * n_phys[i];
-    n_phys /= std::sqrt(n_norm);
+    n_norm = std::sqrt(n_norm);
+    std::for_each(n_phys.begin(), n_phys.end(), [n_norm](auto& n) { return n / n_norm; });
 
-    // Compute det(J_C J_f) as it is the mapping to the reference facet
-    xt::xtensor<double, 2> J_f = xt::view(ref_jacobians, facet_index, xt::all(), xt::all());
-    xt::xtensor<double, 2> J_tot = xt::zeros<double>({J.shape(0), J_f.shape(1)});
-    dolfinx::math::dot(J, J_f, J_tot);
-    double detJ = std::fabs(dolfinx::fem::CoordinateElement::compute_jacobian_determinant(J_tot));
-
-    // Get tables for facet
+    // Get number of dofs per cell
     const std::vector<double>& weights = q_weights[facet_index];
-    const xt::xtensor<double, 2>& phi_f = phi[facet_index];
-    const xt::xtensor<double, 3>& dphi_f = dphi[facet_index];
 
-    // Temporary variable for grad(phi) on physical cell
-    xt::xtensor<double, 2> dphi_phys({gdim, num_local_dofs});
+    // Extract basis values of test/trial function
+    cmdspan4_t phi_full(basis.data(), shape);
+    auto phi_f = stdex::submdspan(phi_full, 0, stdex::full_extent, stdex::full_extent, 0);
+    auto dphi_f = stdex::submdspan(phi_full, std::pair(1, tdim + 1), stdex::full_extent,
+                                   stdex::full_extent, 0);
+
+    std::vector<double> dphi_physb(gdim * shape[2]);
+    mdspan2_t dphi_phys(dphi_physb.data(), gdim, shape[2]);
 
     // Loop over quadrature points
     for (std::size_t q = 0; q < weights.size(); q++)
@@ -401,7 +482,7 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
       const double w0 = weights[q] * detJ;
 
       // Precompute J^-T * dphi
-      std::fill(dphi_phys.begin(), dphi_phys.end(), 0);
+      std::fill(dphi_physb.begin(), dphi_physb.end(), 0);
       for (int i = 0; i < num_local_dofs; i++)
         for (int j = 0; j < gdim; j++)
           for (int k = 0; k < tdim; k++)
@@ -414,7 +495,7 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
           // Component is invarient of block size
           double block_invariant_cont = 0;
           for (int s = 0; s < gdim; s++)
-            block_invariant_cont += dphi_phys(s, i) * n_phys(s) * phi_f(q, j);
+            block_invariant_cont += dphi_phys(s, i) * n_phys[s] * phi_f(q, j);
           block_invariant_cont *= w0;
 
           for (int l = 0; l < bs; ++l)
@@ -424,7 +505,7 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
 
             // Add dphi^j/dx_k dphi^i/dx_l
             for (int b = 0; b < bs; ++b)
-              A[row + i * bs + b] += w0 * dphi_phys(l, i) * n_phys(b) * phi_f(q, j);
+              A[row + i * bs + b] += w0 * dphi_phys(l, i) * n_phys[b] * phi_f(q, j);
           }
         }
       }

--- a/cpp/surface_kernels.hpp
+++ b/cpp/surface_kernels.hpp
@@ -13,7 +13,6 @@
 #include <dolfinx/common/math.h>
 #include <dolfinx/fem/FiniteElement.h>
 #include <dolfinx/fem/FunctionSpace.h>
-
 namespace dolfinx_cuas
 {
 
@@ -110,7 +109,7 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
 
     // Reshape coordinate dofs
     cmdspan2_t coords(coordinate_dofs, std::array<std::size_t, 2>{num_coordinate_dofs, gdim});
-    auto c_view = stdex::submdspan(coords, stdex::full_extent, std::pair{1, gdim});
+    auto c_view = stdex::submdspan(coords, stdex::full_extent, std::pair{0, gdim});
 
     //  FIXME: Assumed constant, i.e. only works for simplices
     assert(is_affine);
@@ -179,7 +178,7 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
 
     // Reshape coordinate dofs
     cmdspan2_t coords(coordinate_dofs, std::array<std::size_t, 2>{num_coordinate_dofs, gdim});
-    auto c_view = stdex::submdspan(coords, stdex::full_extent, std::pair{1, gdim});
+    auto c_view = stdex::submdspan(coords, stdex::full_extent, std::pair{0, gdim});
 
     // Compute Jacobian and determinant on facet
     std::vector<double> Jb(gdim * tdim);
@@ -255,7 +254,7 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
 
     // Reshape coordinate dofs
     cmdspan2_t coords(coordinate_dofs, std::array<std::size_t, 2>{num_coordinate_dofs, gdim});
-    auto c_view = stdex::submdspan(coords, stdex::full_extent, std::pair{1, gdim});
+    auto c_view = stdex::submdspan(coords, stdex::full_extent, std::pair{0, gdim});
 
     //  FIXME: Assumed constant, i.e. only works for simplices
     assert(is_affine);
@@ -333,7 +332,7 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
 
     // Reshape coordinate dofs
     cmdspan2_t coords(coordinate_dofs, std::array<std::size_t, 2>{num_coordinate_dofs, gdim});
-    auto c_view = stdex::submdspan(coords, stdex::full_extent, std::pair{1, gdim});
+    auto c_view = stdex::submdspan(coords, stdex::full_extent, std::pair{0, gdim});
 
     //  FIXME: Assumed constant, i.e. only works for simplices
     assert(is_affine);
@@ -424,7 +423,7 @@ kernel_fn<T> generate_surface_kernel(std::shared_ptr<const dolfinx::fem::Functio
 
     // Reshape coordinate dofs
     cmdspan2_t coords(coordinate_dofs, std::array<std::size_t, 2>{num_coordinate_dofs, gdim});
-    auto c_view = stdex::submdspan(coords, stdex::full_extent, std::pair{1, gdim});
+    auto c_view = stdex::submdspan(coords, stdex::full_extent, std::pair{0, gdim});
 
     //  FIXME: Assumed constant, i.e. only works for simplices
     assert(is_affine);

--- a/cpp/vector_kernels.hpp
+++ b/cpp/vector_kernels.hpp
@@ -61,14 +61,14 @@ kernel_fn<T> generate_vector_kernel(std::shared_ptr<const dolfinx::fem::Function
   cmap.tabulate(1, std::span(points.data(), points.size()), points.shape(), coordinate_basis);
 
   const bool is_affine = cmap.is_affine();
-
+  const std::array<std::size_t, 2> cd_shape = {num_coordinate_dofs, 3};
   // 1 * v * dx, v TestFunction
   // =====================================================================================
   kernel_fn<T> rhs = [=](T* b, const T* c, const T* w, const double* coordinate_dofs,
                          const int* entity_local_index, const std::uint8_t* quadrature_permutation)
   {
     // Reshape and truncate 3D coordinate dofs
-    cmdspan2_t coords(coordinate_dofs, std::array<std::size_t, 2>{num_coordinate_dofs, gdim});
+    cmdspan2_t coords(coordinate_dofs, cd_shape);
     auto c_view = stdex::submdspan(coords, stdex::full_extent, std::pair{0, gdim});
 
     assert(is_affine);
@@ -188,7 +188,7 @@ kernel_fn<T> generate_surface_vector_kernel(std::shared_ptr<const dolfinx::fem::
   auto normal_shape = normals.second;
 
   const bool is_affine = cmap.is_affine();
-
+  const std::array<std::size_t, 2> cd_shape = {num_coordinate_dofs, 3};
   // Define kernels
   // v*ds, v TestFunction
   // =====================================================================================
@@ -203,7 +203,7 @@ kernel_fn<T> generate_surface_vector_kernel(std::shared_ptr<const dolfinx::fem::
     auto [cbasis, cshape] = coordinate_basis_values[facet_index];
 
     // Reshape coordinate dofs
-    cmdspan2_t coords(coordinate_dofs, std::array<std::size_t, 2>{num_coordinate_dofs, gdim});
+    cmdspan2_t coords(coordinate_dofs, cd_shape);
     auto c_view = stdex::submdspan(coords, stdex::full_extent, std::pair{0, gdim});
 
     //  FIXME: Assumed constant, i.e. only works for simplices


### PR DESCRIPTION
Rewrites all assembly kernels in C++ to use `mdspan` istead of xtensors for shaping basis functions.